### PR TITLE
add basic oneshot

### DIFF
--- a/firmware/KeyScanner.cpp
+++ b/firmware/KeyScanner.cpp
@@ -158,6 +158,9 @@ void KeyScanner::updateBuffer(uint8_t layer)
                  * define behavior of
                  * toggle and oneshot keys 
                  * respectively
+                 *
+                 * empty oneshot when a keycode that's before
+                 * the modifiers is pressed
                  */
                 if (activation.second == 1) 
                 {
@@ -178,11 +181,8 @@ void KeyScanner::updateBuffer(uint8_t layer)
                 {
                     oneshotBuffer.push_back(activation.first);
                 }
-                else 
+                else if (activation.first < 0xE0) 
                 {
-                    /*
-                     * TODO: when should oneshot buffer be emptied?
-                     */
                     emptyOneshot = true;
                 }
             }

--- a/firmware/advanced_keycodes.h
+++ b/firmware/advanced_keycodes.h
@@ -15,5 +15,6 @@
 #define MOD_RGUI (128 << 8)
 
 #define TG(KC) ((1 << 16) | KC)
+#define OS(KC) ((2 << 16) | KC)
 
 #endif


### PR DESCRIPTION
Oneshots stored in a buffer, this is release when a non toggle/oneshot keycode smaller than a modifier is pressed - so not when layers or modifiers are pressed.