### PR TITLE
Update path to bluemicro from macos build script

### DIFF
--- a/build/macos/build-macos
+++ b/build/macos/build-macos
@@ -23,7 +23,7 @@ nrf52PackagePath="$arduinoDataPath/packages/adafruit/hardware/nrf52"
 
 scriptPath="$(dirname "$BASH_SOURCE")"
 
-blueMicroPath=$(cd $scriptPath/.. && pwd)
+blueMicroPath=$(cd $scriptPath/../.. && pwd)
 firmwarePath="${blueMicroPath}/firmware"
 outputPath="${blueMicroPath}/output"
 buildPath="${outputPath}/.build"


### PR DESCRIPTION
bluemicro is two levels below `build/macos/build-macos` and thus would cause build problem:

```
$ bash build-macos -v ErgoTravel:default:left

-----------------------------------------------------------------------
   Arduino BlueMicro Build Script
-----------------------------------------------------------------------

Building ErgoTravel:default:left

Checking file locations
-----------------------------------
Arduino Installation... OK
Arduino Data Location... OK
Adafruit nRF52 Package... OK

Compiling
-----------------------------------
cp: /Users/kyle/Projects/tmp/BlueMicro_BLE/build/firmware/*: No such file or directory
```