### PR TITLE
Copy over correct keyboard keymap source

### DIFF
--- a/build/macos/build-macos
+++ b/build/macos/build-macos
@@ -47,10 +47,12 @@ arduino_compile() {
 
    printf "$keyboard:$keymap:$target... "
 
-   keymapFile="$keyboardsPath/$keyboard/keymaps/$keymap/keymap.h"
+   keymapHeaderFile="$keyboardsPath/$keyboard/keymaps/$keymap/keymap.h"
+   keymapSourceFile="$keyboardsPath/$keyboard/keymaps/$keymap/keymap.cpp"
    configFile="$keyboardsPath/$keyboard/$target/keyboard_config.h"
 
-   cp -f $keymapFile $sourcePath/
+   cp -f $keymapHeaderFile $sourcePath/
+   cp -f $keymapSourceFile $sourcePath/
    cp -f $configFile $sourcePath/
 
    if $continueOnError; then


### PR DESCRIPTION
Keyboards keymap source was ignored and instead a default file was used because the source was not copied to the build directory.

NOTE this would be better to use `install` because that won't copy the file and updated the last modified timestamp when it hasn't changed, that way we can work towards incremental compilation. Outside the scope of this PR.