### PR TITLE
Script looks for Adafruit nrf52 version

### DIFF
--- a/build/windows/flash_serial.bat
+++ b/build/windows/flash_serial.bat
@@ -9,7 +9,7 @@ if exist ..\..\output\%~1\%~1-%~2-%~3.zip (
 	goto flash
 ) else (
 	@echo Compiled zip package not found: running build script first.
-	powershell ./build-windows.ps1 %~1 %~2 %~3
+	powershell ./build.ps1 %~1 %~2 %~3
 
 	if exist ..\..\output\%~1\%~1-%~2-%~3.zip (
 		goto flash
@@ -24,9 +24,12 @@ if exist ..\..\output\%~1\%~1-%~2-%~3.zip (
 
 
 :flash
-   	echo Flashing %~1-%~2-%~3 over serial port %~4
-	%localappdata%\Arduino15\packages\adafruit\hardware\nrf52\0.9.0\tools\adafruit-nrfutil\win32\adafruit-nrfutil.exe --verbose dfu serial -pkg ..\..\output\%~1\%~1-%~2-%~3.zip -p %~4 -b 115200 --singlebank
-
+   	@echo Flashing %~1-%~2-%~3 over serial port %~4
+   	set prefix=%localappdata%\Arduino15\packages\adafruit\hardware\nrf52\
+   	set postfix=tools\adafruit-nrfutil\win32\adafruit-nrfutil.exe --verbose dfu serial -pkg ..\..\output\%~1\%~1-%~2-%~3.zip -p %~4 -b 115200 --singlebank
+   	set search_cmd="dir /b %prefix%"
+   	FOR /F "tokens=*" %%i IN (' %search_cmd% ') DO SET ver=%%i
+   	%prefix%\%ver%\%postfix%
 
 :usage
 	@echo Usage: flash_serial keyboard keymap target serial-port


### PR DESCRIPTION
Script works from Powershell and command prompt on Windows 10, but relies on Adafruit's directory structure having only a single folder at "%localappdata%\Arduino15\packages\adafruit\hardware\nrf52" (that is, the version folder). If this structure changes, the script will break, but it can be improved with an if statement and some expression matching in the future.