### PR TITLE
Fixed keyboard compile loop

### DIFF
--- a/build/windows/build.ps1
+++ b/build/windows/build.ps1
@@ -287,6 +287,7 @@ if(Test-Path -Path $SourceDir) {
 Copy-Item -Path $FirmwareDir -Recurse -Destination $SourceDir -Container
 
 Write-Verbose "Discovering keyboards"
+Write-Verbose $KeyboardsDir
 Get-ChildItem $KeyboardsDir | ?{ $_.PSIsContainer } | Foreach-Object {
 
     $keyboard = $_.Name
@@ -312,13 +313,14 @@ Get-ChildItem $KeyboardsDir | ?{ $_.PSIsContainer } | Foreach-Object {
     }
 
     foreach ($keymap in $keymaps) {
+        
         if ($SelectedKeymap -ne "all" -and $SelectedKeymap -ne $keymap) {
-            return
+            continue
         }
 
         foreach ($target in $targets) {
             if ($SelectedTarget -ne "all" -and $SelectedTarget -ne $target) {
-                return
+                continue
             }
 
             Compile-Board $keyboard $target $keymap


### PR DESCRIPTION
Intended functionality:
- Discover keymaps
- Discover targets
- Loop through keymaps until exhausted or keymap is found
- Loop through targets until exhausted or target found
- Compile keymap/target if found, otherwise exit

Existing functionality:
Exits if first keymap is not the selected keymap. Similar for target.

Fix:
Use `continue` command instead of `return` inside comparison loop.