### PR TITLE
Fix layered keys being released if the layer key is released

### DIFF
--- a/docs/configuration_keymap.md
+++ b/docs/configuration_keymap.md
@@ -11,7 +11,7 @@ A single keycode field is made up of four different pieces of information:
 
 ### The activation method
 This is how the key is activated. options are:
-* PRESS: it is pressed.  This is the normal operation of a keyboard where a key will be sent, then repeated until the key is released.  If you want to use another activation method, use **KC_NO** in the standard PRESS to make sure that the standard activations don't get sent to the computer.
+* PRESS: it is pressed.  This is the normal operation of a keyboard where a key will be sent, and kept in the HID report until the key is released.  If you want to use another activation method, use **KC_NO** in the standard PRESS to make sure that the standard activations don't get sent to the computer.
 * MT\_TAP: it is pressed and then released.  The key is sent as soon as the key is released.  
 * MT\_HOLD: it is pressed and held.  The key is sent when the time limit expires.  The key is not repeated.  HOLD is useful for toggling modifiers or layers.
 * DT\_TAP: it is pressed, released and not pressed again for DOUBLETAP\_TIME\_LIMIT. The keyboard will wait for the double tap time limit until the single tap key is sent.
@@ -22,9 +22,9 @@ There is a difference between MT\_TAP and DT\_TAP:  The key difference is when t
 
 Note: if you receive repeated keypresses, check that you do not have PRESS, MT_TAP and DT_TAP are not all defined.  
 It is recommended that you use one of the 3 methods and do not combine them:
-* PRESS: key is sent with every HID report, The computer will automatically detect this and repeat the keycode until a HID report without the keycode is received. Default behaviour.  Note that if the computer loose connection with the keyboard, it will not receive the "empty" HID report and will start repeating the keypress.
-* MT_TAP/MT_HOLD: This adds a timer to the keyboard to detect when the key is being held.  When held, a different keycode can be sent.  For each activation state of this method, a single HID report will be sent.
-* DT_TAP/DT_DOUBLETAP: This adds a timer to  the keyboard to detect if the same key is pressed again within a given time period.  When double-tapped, a different keycode can be sent. For each activation state of this method, a single HID report will be sent.
+* PRESS: key is sent with every HID report. The computer will automatically detect this and repeat the keycode until a HID report without the keycode is received. Default behaviour.  Note that if the computer loose connection with the keyboard, it will not receive the "empty" HID report and will start repeating the keypress.
+* MT_TAP/MT_HOLD: This adds a timer to the keyboard to detect when the key is being held.  When held, a different keycode can be sent.  For each activation state of this method, a single HID report will be sent and then immediately released.
+* DT_TAP/DT_DOUBLETAP: This adds a timer to  the keyboard to detect if the same key is pressed again within a given time period.  When double-tapped, a different keycode can be sent. For each activation state of this method, a single HID report will be sent and then immediately released.
 
 ### The activation duration
 Once Activated, sending of the keycode can be sent at different times:

--- a/docs/configuration_keymap.md
+++ b/docs/configuration_keymap.md
@@ -15,7 +15,7 @@ This is how the key is activated. options are:
 * MT\_TAP: it is pressed and then released.  The key is sent as soon as the key is released.  
 * MT\_HOLD: it is pressed and held.  The key is sent when the time limit expires.  The key is not repeated.  HOLD is useful for toggling modifiers or layers.
 * DT\_TAP: it is pressed, released and not pressed again for DOUBLETAP\_TIME\_LIMIT. The keyboard will wait for the double tap time limit until the single tap key is sent.
-* DT\_DOUBLTAP: it is pressed, released and tapped again within a certain time.  The keyboard will send the key as soon as a double tap is detected.
+* DT\_DOUBLETAP: it is pressed, released and tapped again within a certain time.  The keyboard will send the key as soon as a double tap is detected.
 (DOUBLETAP\_TIME\_LIMIT duration (in ms) is defined in KeyStates.h)
 
 There is a difference between MT\_TAP and DT\_TAP:  The key difference is when the keycode is sent.  With MT, the keycode is sent as soon as the key is released.  With DT, the keycode is sent some time after the key is released: delay time is there to detect the double taps.

--- a/firmware/Key.cpp
+++ b/firmware/Key.cpp
@@ -23,7 +23,7 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 Key::Key(uint32_t activation) 
 {
     activations[0][0] = static_cast<uint16_t>(activation & 0x0000FFFF); 
-    durations[0][0] = static_cast<uint8_t>((activation & 0x00FF0000) >> 16);
+    durations[0][0] = static_cast<Duration>((activation & 0x00FF0000) >> 16);
 
     //last method is the "release" method
     lastMethod = Method::NONE;
@@ -57,7 +57,7 @@ void Key::addActivation(const uint8_t layer, const Method method, const uint32_t
     }
 
     activations[layer][methodIndex] = keycode;
-    durations[layer][methodIndex] = static_cast<uint8_t>((activation & 0x00FF0000) >> 16);
+    durations[layer][methodIndex] = static_cast<Duration>((activation & 0x00FF0000) >> 16);
 
     /*
      * tell the state to make sure to look for the added
@@ -76,7 +76,7 @@ void Key::clear(const unsigned long currentMillis)
     state.clear(currentMillis);
 }
 
-std::pair<uint16_t, uint8_t> Key::getPair(uint8_t layer)
+std::pair<uint16_t, Duration> Key::getActiveActivation(uint8_t layer)
 {
     Method method;
 
@@ -99,7 +99,7 @@ std::pair<uint16_t, uint8_t> Key::getPair(uint8_t layer)
             break;
         default:
             lastMethod = Method::NONE;
-            return std::make_pair(0, 0);
+            return std::make_pair(0, Duration::MOMENTARY);
     }
 
     const auto methodIndex = static_cast<int>(method);
@@ -111,14 +111,14 @@ std::pair<uint16_t, uint8_t> Key::getPair(uint8_t layer)
      * this is to make sure that mt/dt activations
      * are only read once - important when toggling
      */
-    if ((lastMethod == Method::PRESS && durations[layer][methodIndex] != 1) || method != lastMethod)
+    if ((lastMethod == Method::PRESS && durations[layer][methodIndex] != Duration::TOGGLE) || method != lastMethod)
     {
         lastMethod = method;
         return std::make_pair(activations[layer][methodIndex], durations[layer][methodIndex]);
     }
     else 
     {
-        return std::make_pair(0, 0);
+        return std::make_pair(0, Duration::MOMENTARY);
     }
 }
 

--- a/firmware/Key.cpp
+++ b/firmware/Key.cpp
@@ -26,13 +26,14 @@ Key::Key(uint32_t activation)
     durations[0][0] = static_cast<uint8_t>((activation & 0x00FF0000) >> 16);
 
     //last method is the "release" method
-    lastMethod = 5;
+    lastMethod = Method::NONE;
 }
 
 //should be called with 
-void Key::addActivation(const uint8_t layer, const uint8_t method, const uint32_t activation) 
+void Key::addActivation(const uint8_t layer, const Method method, const uint32_t activation) 
 {
     auto keycode = static_cast<uint16_t>(activation & 0x0000FFFF);
+    auto methodIndex = static_cast<int>(method);
 
     /*
      * if the activation is transparent,
@@ -52,11 +53,11 @@ void Key::addActivation(const uint8_t layer, const uint8_t method, const uint32_
             break;
         }
 
-        keycode = activations[--tempLayer][method];
+        keycode = activations[--tempLayer][methodIndex];
     }
 
-    activations[layer][method] = keycode;
-    durations[layer][method] = static_cast<uint8_t>((activation & 0x00FF0000) >> 16);
+    activations[layer][methodIndex] = keycode;
+    durations[layer][methodIndex] = static_cast<uint8_t>((activation & 0x00FF0000) >> 16);
 
     /*
      * tell the state to make sure to look for the added
@@ -77,29 +78,31 @@ void Key::clear(const unsigned long currentMillis)
 
 std::pair<uint16_t, uint8_t> Key::getPair(uint8_t layer)
 {
-    uint8_t method;
+    Method method;
 
     switch(state.getState()) 
     {
         case KeyState::State::PRESSED:
-            method = 0;
+            method = Method::PRESS;
             break;
         case KeyState::State::MT_TAPPED:
-            method = 1;
+            method = Method::MT_TAP;
             break;
         case KeyState::State::MT_HELD:
-            method = 2;
+            method = Method::MT_HOLD;
             break;
         case KeyState::State::DT_TAPPED:
-            method = 3;
+            method = Method::DT_TAP;
             break;
         case KeyState::State::DT_DOUBLETAPPED:
-            method = 4;
+            method = Method::DT_DOUBLETAP;
             break;
         default:
-            lastMethod = 5;
+            lastMethod = Method::NONE;
             return std::make_pair(0, 0);
     }
+
+    const auto methodIndex = static_cast<int>(method);
 
     /*
      * check that the last method is different from 
@@ -108,10 +111,10 @@ std::pair<uint16_t, uint8_t> Key::getPair(uint8_t layer)
      * this is to make sure that mt/dt activations
      * are only read once - important when toggling
      */
-    if ((lastMethod == 0 && durations[layer][method] != 1) || method != lastMethod)
+    if ((lastMethod == Method::PRESS && durations[layer][methodIndex] != 1) || method != lastMethod)
     {
         lastMethod = method;
-        return std::make_pair(activations[layer][method], durations[layer][method]);
+        return std::make_pair(activations[layer][methodIndex], durations[layer][methodIndex]);
     }
     else 
     {

--- a/firmware/Key.h
+++ b/firmware/Key.h
@@ -18,6 +18,7 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 
 */
 #include "KeyState.h"
+#include "advanced_keycodes.h"
 #include "hid_keycodes.h"
 #include <array>
 #include <utility>
@@ -26,7 +27,7 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define KEY_H
 
 using ActArray = std::array<std::array<uint16_t, 5>, 2>;
-using DurArray = std::array<std::array<uint8_t, 5>, 2>;
+using DurArray = std::array<std::array<Duration, 5>, 2>;
 
 class Key {
     public:
@@ -35,7 +36,7 @@ class Key {
 
         void addActivation(const uint8_t layer, const Method method, const uint32_t activation);
 
-        std::pair<uint16_t, uint8_t> getPair(uint8_t layer);
+        std::pair<uint16_t, Duration> getActiveActivation(uint8_t layer);
 
         Key(uint32_t activation);
 

--- a/firmware/Key.h
+++ b/firmware/Key.h
@@ -33,14 +33,14 @@ class Key {
         void press(unsigned long currentMillis);
         void clear(unsigned long currentMillis);
 
-        void addActivation(const uint8_t layer, const uint8_t method, const uint32_t activation);
+        void addActivation(const uint8_t layer, const Method method, const uint32_t activation);
 
         std::pair<uint16_t, uint8_t> getPair(uint8_t layer);
 
         Key(uint32_t activation);
 
     private:
-        uint8_t lastMethod;
+        Method lastMethod;
         KeyState state;
 
         ActArray activations;

--- a/firmware/Key.h
+++ b/firmware/Key.h
@@ -42,6 +42,7 @@ class Key {
 
     private:
         Method lastMethod;
+        std::pair<uint16_t, Duration> lastActivation;
         KeyState state;
 
         ActArray activations;

--- a/firmware/KeyScanner.cpp
+++ b/firmware/KeyScanner.cpp
@@ -185,6 +185,7 @@ void KeyScanner::updateBuffer(uint8_t layer)
                 }
                 else if (duration == Duration::ONE_SHOT)
                 {
+                    // TODO: Holding the key will keep appending to this buffer?
                     oneshotBuffer.push_back(activeKeycode);
                 }
                 else if (activeKeycode < 0xE0) 

--- a/firmware/KeyScanner.cpp
+++ b/firmware/KeyScanner.cpp
@@ -18,6 +18,8 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 
 */
 #include "KeyScanner.h"
+#include <tuple>
+
 // ToDo: There seems to be lots of redundency in data.
 // ToDo: consider interrupts or GPIOTE
 // ToDo: there must be a better way to debounce
@@ -150,12 +152,13 @@ void KeyScanner::updateBuffer(uint8_t layer)
     for(int row = 0; row < MATRIX_ROWS; ++row) {
         for (auto& key : matrix[row]) 
         {
-            //pair of activation/duration
-            auto activation = key.getPair(layer);
+            uint16_t activeKeycode;
+            Duration duration;
+            std::tie(activeKeycode, duration) = key.getActiveActivation(layer);
 
-            if (activation.first != 0) 
+            if (activeKeycode != 0) 
             {
-                activeKeys.push_back(activation.first);
+                activeKeys.push_back(activeKeycode);
 
                 /*
                  * define behavior of
@@ -165,9 +168,9 @@ void KeyScanner::updateBuffer(uint8_t layer)
                  * empty oneshot when a keycode that's before
                  * the modifiers is pressed
                  */
-                if (activation.second == 1) 
+                if (duration == Duration::TOGGLE) 
                 {
-                    auto it = std::find(toggleBuffer.begin(), toggleBuffer.end(), activation.first);
+                    auto it = std::find(toggleBuffer.begin(), toggleBuffer.end(), activeKeycode);
 
                     if (it != toggleBuffer.end())
                     {
@@ -175,16 +178,16 @@ void KeyScanner::updateBuffer(uint8_t layer)
                     }
                     else 
                     {
-                        toggleBuffer.push_back(activation.first);
+                        toggleBuffer.push_back(activeKeycode);
                     }
 
 
                 }
-                else if (activation.second == 2)
+                else if (duration == Duration::ONE_SHOT)
                 {
-                    oneshotBuffer.push_back(activation.first);
+                    oneshotBuffer.push_back(activeKeycode);
                 }
-                else if (activation.first < 0xE0) 
+                else if (activeKeycode < 0xE0) 
                 {
                     emptyOneshot = true;
                 }

--- a/firmware/KeyState.cpp
+++ b/firmware/KeyState.cpp
@@ -23,18 +23,18 @@ KeyState::KeyState() {
     state = State::RELEASED;
     lastChanged = 0;
     canDoubletap = false;
-    checkDT = false;
-    checkMT = false;
+    checkDoubleTap = false;
+    checkModTap = false;
 }
 
-void KeyState::addMethod(uint8_t method)
+void KeyState::addMethod(Method method)
 {
-    if (method == 1 || method == 2) {
-        checkMT = true;
+    if (method == Method::MT_TAP || method == Method::MT_HOLD) {
+        checkModTap = true;
     }
-    else if (method == 3 || method == 4) 
+    else if (method == Method::DT_TAP || method == Method::DT_DOUBLETAP) 
     {
-        checkDT = true;
+        checkDoubleTap = true;
     }
 }
 
@@ -49,14 +49,14 @@ void KeyState::press(unsigned long currentMillis)
      * if the previous state isn't pressed, then set it to 
      * pressed now and update the change time
      */
-    if (state == State::PRESSED && timeElapsed > TIME_TILL_HOLD && checkMT) 
+    if (state == State::PRESSED && timeElapsed > TIME_TILL_HOLD && checkModTap) 
     {
         state = State::MT_HELD;
         lastChanged = currentMillis;
     }
     else if ((state == State::RELEASED || state == State::MT_TAPPED))
     {
-        if (canDoubletap && checkDT) 
+        if (canDoubletap && checkDoubleTap) 
         {
             state = State::DT_DOUBLETAPPED;
             canDoubletap = false;
@@ -78,12 +78,12 @@ void KeyState::clear(unsigned long currentMillis)
 
     // if the previous state was pressed, then set the state to 
     // tapped, otherwise set it to released
-    if (state == State::PRESSED && checkMT)
+    if (state == State::PRESSED && checkModTap)
     {
         state = State::MT_TAPPED;
         lastChanged = currentMillis;
     }
-    else if (timeElapsed > DOUBLETAP_TIME_LIMIT && canDoubletap && checkDT) 
+    else if (timeElapsed > DOUBLETAP_TIME_LIMIT && canDoubletap && checkDoubleTap) 
     {
         state = State::DT_TAPPED;
         lastChanged = currentMillis;

--- a/firmware/KeyState.h
+++ b/firmware/KeyState.h
@@ -26,6 +26,15 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define TIME_TILL_HOLD 600
 #define TIME_TILL_RELEASE 80
 
+enum class Method {
+    PRESS = 0,
+    MT_TAP = 1,
+    MT_HOLD = 2,
+    DT_TAP = 3,
+    DT_DOUBLETAP = 4,
+    NONE = 5,
+};
+
 class KeyState 
 {
     public:
@@ -34,7 +43,7 @@ class KeyState
         void press(unsigned long currentMillis);
         void clear(unsigned long currentMillis);
 
-        void addMethod(uint8_t method);
+        void addMethod(Method method);
 
         enum class State
         {
@@ -52,7 +61,7 @@ class KeyState
 
     private:
         bool canDoubletap;
-        bool checkMT, checkDT;
+        bool checkModTap, checkDoubleTap;
 
         //std::array<5, bool> checkMethods;
 

--- a/firmware/advanced_keycodes.h
+++ b/firmware/advanced_keycodes.h
@@ -22,6 +22,12 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #ifndef ADVANCED_KEYCODES_H
 #define ADVANCED_KEYCODES_H
 
+enum class Duration {
+    MOMENTARY = 0,
+    TOGGLE = 1,
+    ONE_SHOT = 2,
+};
+
 #define MOD(M, KC) ((uint16_t) KC | (uint16_t) M)
 
 #define MOD_LCTRL (1 << 8)
@@ -33,8 +39,8 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define MOD_RALT (64 << 8)
 #define MOD_RGUI (128 << 8)
 
-#define TG(KC) ((1 << 16) | KC)
-#define OS(KC) ((2 << 16) | KC)
+#define TG(KC) ((static_cast<int>(Duration::TOGGLE) << 16) | KC)
+#define OS(KC) ((static_cast<int>(Duration::ONE_SHOT) << 16) | KC)
 
 #define S(KC) MOD(MOD_LSHIFT, KC)
 

--- a/firmware/keyboards/25/keymaps/test/keymap.cpp
+++ b/firmware/keyboards/25/keymaps/test/keymap.cpp
@@ -45,7 +45,7 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
         }
     }
 

--- a/firmware/keyboards/25/keymaps/test/keymap.h
+++ b/firmware/keyboards/25/keymaps/test/keymap.h
@@ -33,13 +33,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L1  1
 #define _L2  2
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/4x4Backpack/keymaps/jpcobs/keymap.cpp
+++ b/firmware/keyboards/4x4Backpack/keymaps/jpcobs/keymap.cpp
@@ -42,7 +42,7 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
         }
     }
 

--- a/firmware/keyboards/4x4Backpack/keymaps/jpcobs/keymap.h
+++ b/firmware/keyboards/4x4Backpack/keymaps/jpcobs/keymap.h
@@ -49,11 +49,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 
 #define _QWERTY 0
 #define _L1  1
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
 
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;

--- a/firmware/keyboards/4x4Backpack/keymaps/numpad/keymap.cpp
+++ b/firmware/keyboards/4x4Backpack/keymaps/numpad/keymap.cpp
@@ -42,7 +42,7 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
         }
     }
 

--- a/firmware/keyboards/4x4Backpack/keymaps/numpad/keymap.h
+++ b/firmware/keyboards/4x4Backpack/keymaps/numpad/keymap.h
@@ -32,11 +32,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 
 #define _QWERTY 0
 #define _L1  1
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
 
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;

--- a/firmware/keyboards/4x4x4x4Backpack/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/4x4x4x4Backpack/keymaps/default/keymap.cpp
@@ -50,8 +50,8 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
         }
     }
 

--- a/firmware/keyboards/4x4x4x4Backpack/keymaps/default/keymap.h
+++ b/firmware/keyboards/4x4x4x4Backpack/keymaps/default/keymap.h
@@ -34,12 +34,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L1  1
 #define _L2  2
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/ErgoTravel/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/ErgoTravel/keymaps/default/keymap.cpp
@@ -128,9 +128,9 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 
@@ -232,9 +232,9 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 

--- a/firmware/keyboards/ErgoTravel/keymaps/default/keymap.h
+++ b/firmware/keyboards/ErgoTravel/keymaps/default/keymap.h
@@ -33,12 +33,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L2  2
 #define _L3  3
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/Laplace/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/Laplace/keymaps/default/keymap.cpp
@@ -53,8 +53,8 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
         }
     }
 

--- a/firmware/keyboards/Laplace/keymaps/default/keymap.h
+++ b/firmware/keyboards/Laplace/keymaps/default/keymap.h
@@ -35,12 +35,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L2  2
 #define _L3  3
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/Levinson/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/Levinson/keymaps/default/keymap.cpp
@@ -72,9 +72,9 @@ KEYMAP(
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 
@@ -129,9 +129,9 @@ KEYMAP(
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 

--- a/firmware/keyboards/Levinson/keymaps/default/keymap.h
+++ b/firmware/keyboards/Levinson/keymaps/default/keymap.h
@@ -35,12 +35,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L2  2
 #define _L3  3
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/Levinson/keymaps/resfury/keymap.cpp
+++ b/firmware/keyboards/Levinson/keymaps/resfury/keymap.cpp
@@ -92,8 +92,8 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_LOWER, _PRESS, lower[row][col]);
-            matrix[row][col].addActivation(_RAISE, _PRESS, raise[row][col]);
+            matrix[row][col].addActivation(_LOWER, Method::PRESS, lower[row][col]);
+            matrix[row][col].addActivation(_RAISE, Method::PRESS, raise[row][col]);
         }
     }
 
@@ -141,8 +141,8 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_LOWER, _PRESS, lower[row][col]);
-            matrix[row][col].addActivation(_RAISE, _PRESS, raise[row][col]);
+            matrix[row][col].addActivation(_LOWER, Method::PRESS, lower[row][col]);
+            matrix[row][col].addActivation(_RAISE, Method::PRESS, raise[row][col]);
         }
     }
 

--- a/firmware/keyboards/Levinson/keymaps/resfury/keymap.h
+++ b/firmware/keyboards/Levinson/keymaps/resfury/keymap.h
@@ -52,12 +52,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _LOWER   1
 #define _RAISE   2
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/airgodox/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/airgodox/keymaps/default/keymap.cpp
@@ -50,7 +50,7 @@ void setupKeymap()
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
         }
     }
 
@@ -58,8 +58,8 @@ void setupKeymap()
      * add special, single activations with the 
      * layer, activation method and activation
      */
-    matrix[2][3].addActivation(_QWERTY, _MT_TAP, KC_Y);
-    matrix[1][1].addActivation(_QWERTY, _MT_TAP, TG(KC_LSHIFT));
+    matrix[2][3].addActivation(_QWERTY, Method::MT_TAP, KC_Y);
+    matrix[1][1].addActivation(_QWERTY, Method::MT_TAP, TG(KC_LSHIFT));
 }
 
 #else
@@ -92,7 +92,7 @@ void setupKeymap()
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
         }
     }
 
@@ -100,8 +100,8 @@ void setupKeymap()
      * add special, single activations with the 
      * layer, activation method and activation
      */
-    matrix[2][3].addActivation(_QWERTY, _MT_TAP, KC_Y);
-    matrix[1][1].addActivation(_QWERTY, _MT_TAP, TG(KC_LSHIFT));
+    matrix[2][3].addActivation(_QWERTY, Method::MT_TAP, KC_Y);
+    matrix[1][1].addActivation(_QWERTY, Method::MT_TAP, TG(KC_LSHIFT));
 }
 
 

--- a/firmware/keyboards/airgodox/keymaps/default/keymap.h
+++ b/firmware/keyboards/airgodox/keymaps/default/keymap.h
@@ -31,11 +31,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 
 #define _QWERTY 0
 #define _L1  1
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
 
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;

--- a/firmware/keyboards/airgodox/keymaps/nonconst/keymap.cpp
+++ b/firmware/keyboards/airgodox/keymaps/nonconst/keymap.cpp
@@ -60,14 +60,14 @@ void setupKeymap()
     /*
      * add the other layers
      */
-    addLayers({std::make_tuple(_L1, _PRESS, layer1)});
+    addLayers({std::make_tuple(_L1, Method::PRESS, layer1)});
 
     /* 
      * add special, single activations with the 
      * layer, activation method and activation
      */
-    matrix[2][3].addActivation(_QWERTY, _MT_TAP, KC_Y);
-    matrix[1][1].addActivation(_QWERTY, _MT_TAP, TG(KC_LSHIFT));
+    matrix[2][3].addActivation(_QWERTY, Method::MT_TAP, KC_Y);
+    matrix[1][1].addActivation(_QWERTY, Method::MT_TAP, TG(KC_LSHIFT));
 }
 
 #else
@@ -102,7 +102,7 @@ void setupKeymap()
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
         }
     }
 
@@ -110,8 +110,8 @@ void setupKeymap()
      * add special, single activations with the 
      * layer, activation method and activation
      */
-    matrix[2][3].addActivation(_QWERTY, _MT_TAP, KC_Y);
-    matrix[1][1].addActivation(_QWERTY, _MT_TAP, TG(KC_LSHIFT));
+    matrix[2][3].addActivation(_QWERTY, Method::MT_TAP, KC_Y);
+    matrix[1][1].addActivation(_QWERTY, Method::MT_TAP, TG(KC_LSHIFT));
 }
 
 

--- a/firmware/keyboards/airgodox/keymaps/nonconst/keymap.h
+++ b/firmware/keyboards/airgodox/keymaps/nonconst/keymap.h
@@ -33,18 +33,13 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 
 #define _QWERTY 0
 #define _L1  1
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
 
 using layer_t = std::array<std::array<uint32_t, MATRIX_COLS>, MATRIX_ROWS>;
 using main_layer_t = std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS>;
 
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 
-inline void addLayers(const std::vector<std::tuple<uint8_t, uint8_t, layer_t>>& layers) 
+inline void addLayers(const std::vector<std::tuple<uint8_t, Method, layer_t>>& layers) 
 {
     for (int row = 0; row < MATRIX_ROWS; ++row)
     { 

--- a/firmware/keyboards/blueortho/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/blueortho/keymaps/default/keymap.cpp
@@ -51,8 +51,8 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
         }
     }
 

--- a/firmware/keyboards/blueortho/keymaps/default/keymap.h
+++ b/firmware/keyboards/blueortho/keymaps/default/keymap.h
@@ -34,12 +34,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L1  1
 #define _L2  2
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/chocopad/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/chocopad/keymaps/default/keymap.cpp
@@ -50,8 +50,8 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
         }
     }
 

--- a/firmware/keyboards/chocopad/keymaps/default/keymap.h
+++ b/firmware/keyboards/chocopad/keymaps/default/keymap.h
@@ -33,12 +33,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L1  1
 #define _L2  2
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/contra/keymaps/ckofy/keymap.cpp
+++ b/firmware/keyboards/contra/keymaps/ckofy/keymap.cpp
@@ -56,9 +56,9 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 

--- a/firmware/keyboards/contra/keymaps/ckofy/keymap.h
+++ b/firmware/keyboards/contra/keymaps/ckofy/keymap.h
@@ -48,12 +48,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define KC_LOCK MOD(MOD_LGUI, KC_L)		// Lock
 #define KC_DESK MOD(MOD_LGUI, KC_D)		// Desktop
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/contra/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/contra/keymaps/default/keymap.cpp
@@ -50,8 +50,8 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
         }
     }
 

--- a/firmware/keyboards/contra/keymaps/default/keymap.h
+++ b/firmware/keyboards/contra/keymaps/default/keymap.h
@@ -33,12 +33,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L1  1
 #define _L2  2
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/foobar/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/foobar/keymaps/default/keymap.cpp
@@ -60,9 +60,9 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 
@@ -116,9 +116,9 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 

--- a/firmware/keyboards/foobar/keymaps/default/keymap.h
+++ b/firmware/keyboards/foobar/keymaps/default/keymap.h
@@ -35,12 +35,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L2  2
 #define _L3  3
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/gherkin/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/gherkin/keymaps/default/keymap.cpp
@@ -58,9 +58,9 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 

--- a/firmware/keyboards/gherkin/keymaps/default/keymap.h
+++ b/firmware/keyboards/gherkin/keymaps/default/keymap.h
@@ -34,12 +34,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L2  2
 #define _L3  3
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/gherkin/keymaps/huelagus/keymap.cpp
+++ b/firmware/keyboards/gherkin/keymaps/huelagus/keymap.cpp
@@ -87,16 +87,16 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            ADDLAYER(_QWERTY, _MT_TAP , qwerty_tap[row][col]);
-            ADDLAYER(_QWERTY, _MT_HOLD, qwerty_hold[row][col]);
+            ADDLAYER(_QWERTY, Method::MT_TAP , qwerty_tap[row][col]);
+            ADDLAYER(_QWERTY, Method::MT_HOLD, qwerty_hold[row][col]);
 
-            ADDLAYER(_QWERTY,_DT_TAP , qwerty_stap[row][col]);
-            ADDLAYER(_QWERTY,_DT_DOUBLETAP , qwerty_dtap[row][col]);
+            ADDLAYER(_QWERTY, Method::DT_TAP, qwerty_stap[row][col]);
+            ADDLAYER(_QWERTY, Method::DT_DOUBLETAP, qwerty_dtap[row][col]);
       
-            ADDLAYER(_L1, _PRESS, layer1[row][col]);
-            ADDLAYER(_L2, _PRESS, layer2[row][col]);
-            ADDLAYER(_L3, _PRESS, layer3[row][col]);
-            ADDLAYER(_L4, _PRESS, layer4[row][col]);
+            ADDLAYER(_L1, Method::PRESS, layer1[row][col]);
+            ADDLAYER(_L2, Method::PRESS, layer2[row][col]);
+            ADDLAYER(_L3, Method::PRESS, layer3[row][col]);
+            ADDLAYER(_L4, Method::PRESS, layer4[row][col]);
             
         }
     }

--- a/firmware/keyboards/gherkin/keymaps/huelagus/keymap.h
+++ b/firmware/keyboards/gherkin/keymaps/huelagus/keymap.h
@@ -38,12 +38,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L4  4
 #define _L5  5
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/iris/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/iris/keymaps/default/keymap.cpp
@@ -88,9 +88,9 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 
@@ -148,9 +148,9 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 

--- a/firmware/keyboards/iris/keymaps/default/keymap.h
+++ b/firmware/keyboards/iris/keymaps/default/keymap.h
@@ -35,12 +35,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L2  2
 #define _L3  3
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/lets_split/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/lets_split/keymaps/default/keymap.cpp
@@ -64,9 +64,9 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 
@@ -124,9 +124,9 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 

--- a/firmware/keyboards/lets_split/keymaps/default/keymap.h
+++ b/firmware/keyboards/lets_split/keymaps/default/keymap.h
@@ -35,12 +35,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L2  2
 #define _L3  3
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/luddite/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/luddite/keymaps/default/keymap.cpp
@@ -59,8 +59,8 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
         }
     }
 

--- a/firmware/keyboards/luddite/keymaps/default/keymap.h
+++ b/firmware/keyboards/luddite/keymaps/default/keymap.h
@@ -35,12 +35,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L2  2
 #define _L3  3
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/megatreus/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/megatreus/keymaps/default/keymap.cpp
@@ -46,7 +46,7 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
         }
     }
 

--- a/firmware/keyboards/megatreus/keymaps/default/keymap.h
+++ b/firmware/keyboards/megatreus/keymaps/default/keymap.h
@@ -31,11 +31,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 
 #define _QWERTY 0
 #define _L1  1
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
 
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;

--- a/firmware/keyboards/minidox/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/minidox/keymaps/default/keymap.cpp
@@ -61,9 +61,9 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 
@@ -112,9 +112,9 @@ void setupKeymap() {
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 

--- a/firmware/keyboards/minidox/keymaps/default/keymap.h
+++ b/firmware/keyboards/minidox/keymaps/default/keymap.h
@@ -35,12 +35,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L2  2
 #define _L3  3
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 

--- a/firmware/keyboards/semaphore/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/semaphore/keymaps/default/keymap.cpp
@@ -122,9 +122,9 @@ uint32_t layer3[MATRIX_ROWS][MATRIX_COLS] =
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 
@@ -183,9 +183,9 @@ uint32_t layer3[MATRIX_ROWS][MATRIX_COLS] =
     {
         for (int col = 0; col < MATRIX_COLS; ++col)
         {
-            matrix[row][col].addActivation(_L1, _PRESS, layer1[row][col]);
-            matrix[row][col].addActivation(_L2, _PRESS, layer2[row][col]);
-            matrix[row][col].addActivation(_L3, _PRESS, layer3[row][col]);
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, layer3[row][col]);
         }
     }
 

--- a/firmware/keyboards/semaphore/keymaps/default/keymap.h
+++ b/firmware/keyboards/semaphore/keymaps/default/keymap.h
@@ -37,12 +37,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define _L2  2
 #define _L3  3
 
-#define _PRESS 0
-#define _MT_TAP 1
-#define _MT_HOLD 2
-#define _DT_TAP 3
-#define _DT_DOUBLETAP 4
-
 void setupKeymap();
 extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 


### PR DESCRIPTION
Also refactor the Duration and Method usage in this area of the
code to use enums in order to reduce the confusion that can be
caused by the same numeral constants having different meanings
for different cases (e.g. State::MT_TAPPED == 2 but _MT_TAP == 1).

Fixes #83