### PR TITLE
fixing board name for nrf52840 docker build script

### DIFF
--- a/build/docker/nrf52840.sh
+++ b/build/docker/nrf52840.sh
@@ -70,7 +70,7 @@ arduino_compile() {
 
    #Compile
    cmdCompile832="/arduino-cli compile -v --fqbn adafruit:nrf52:feather52832 --build-path $buildPath --build-cache-path $buildCachePath $sourcePath/firmware.ino  -o $buildPath/firmware"
-   cmdCompile840="/arduino-cli compile -v --fqbn adafruit:nrf52:feather52840 --build-path $buildPath --build-cache-path $buildCachePath $sourcePath/firmware.ino  -o $buildPath/firmware"
+   cmdCompile840="/arduino-cli compile -v -fqbn adafruit:nrf52:pca10056:softdevice=s140v6,debug=l0 --build-path $buildPath --build-cache-path $buildCachePath $sourcePath/firmware.ino  -o $buildPath/firmware"
 
    if $verbose; then 
       $cmdCompile840


### PR DESCRIPTION
fixed issue with docker builds for nrf52840 boards