### PR TITLE
added initial support for lost60 keyboard hardware

### DIFF
--- a/firmware/LedRGB.cpp
+++ b/firmware/LedRGB.cpp
@@ -52,10 +52,16 @@ rgb_color hsvToRgb(uint16_t h, uint8_t s, uint8_t v)
 
 void setupRGB(void)
 {
+   #if defined(WS2812B_LED_LOAD_SWITCH) 
+        pinMode(WS2812B_LED_LOAD_SWITCH_PIN, OUTPUT);
+        digitalWrite(WS2812B_LED_LOAD_SWITCH_PIN, HIGH);
+   #endif
+
    pixels.begin(); // INITIALIZE NeoPixel strip object (REQUIRED)
    pixels.setPin(WS2812B_LED_PIN);
    pixels.updateLength(WS2812B_LED_COUNT);
 }
+
 void updateRGBmode(uint32_t mode)
 {
    rgb_mode = mode;
@@ -136,9 +142,14 @@ switch (rgb_mode)
 void suspendRGB(void)
 {
     pixels.clear();
-  for(int i=0; i<WS2812B_LED_COUNT; i++) { // For each pixel...
-    pixels.setPixelColor(i, 0, 0, 0); 
-  }
-  pixels.show();   // Send the updated pixel colors to the hardware.
+
+    for(int i=0; i<WS2812B_LED_COUNT; i++) { // For each pixel...
+        pixels.setPixelColor(i, 0, 0, 0); 
+    }
+    pixels.show();   // Send the updated pixel colors to the hardware.
+
+    #if defined(WS2812B_LED_LOAD_SWITCH) 
+        digitalWrite(WS2812B_LED_LOAD_SWITCH_PIN, LOW);
+    #endif
 }
 

--- a/firmware/audio.cpp
+++ b/firmware/audio.cpp
@@ -18,43 +18,27 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 
 */
 
-#ifndef HARDWAREVARIANTS_H
-#define HARDWAREVARIANTS_H
-
 /*
-The following can be selected from the Tools->Boards Arduino Menu when compiling
-NRF52832_FEATHER
-NRF52840_FEATHER
-NRF52840_ITSYBITSY
-NRF52840_CIRCUITPLAY
-NRF52840_METRO
-NRF52840_PCA10056
+Audio files / library added by Coyt Barringer
 */
 
-#define FEATHERNRF52832 0  // don't do any avr mapping
-#define FEATHERNRF52840 0  // don't do any avr mapping
+#include "audio.h"
+#if AUDIO_ON == 0 
+    //do nothing
+#else
 
-#define BLUEMICROV1_0   1
-#define BLUEMICROV1_1   2
-#define BLUEMICROV2_0   3
-#define BLUEMICROV2_0B  4
-#define BLUEMICROV2_0C  5
-#define BLUENANO1_0     6
-#define BLUENANO2_0     7
-#define BLUEMICROV2_1A  8
-#define BLUEMICRO840V1_0 9  // Needs ARDUINO_NRF52840_PCA10056 on the Arduino IDE
+    void setupAudio(){
+        //setup speaker pins
+        pinMode(SPEAKER_A, OUTPUT);
+        pinMode(SPEAKER_B, OUTPUT);
+
+        digitalWrite(SPEAKER_A, LOW);
+        digitalWrite(SPEAKER_B, LOW);
+
+    }
+
+#endif
 
 
 
-#define COL2ROW       0
-#define ROW2COL       1
 
-#define READ_ON_ROWS       1
-#define READ_ON_COLS       0
-
-#define TEST 0
-#define LEFT 1
-#define RIGHT 2
-#define MASTER 3
-
-#endif  /*HARDWAREVARIANTS_H*/

--- a/firmware/audio.h
+++ b/firmware/audio.h
@@ -18,43 +18,17 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 
 */
 
-#ifndef HARDWAREVARIANTS_H
-#define HARDWAREVARIANTS_H
-
 /*
-The following can be selected from the Tools->Boards Arduino Menu when compiling
-NRF52832_FEATHER
-NRF52840_FEATHER
-NRF52840_ITSYBITSY
-NRF52840_CIRCUITPLAY
-NRF52840_METRO
-NRF52840_PCA10056
+audio files / library added by Coyt Barringer
 */
 
-#define FEATHERNRF52832 0  // don't do any avr mapping
-#define FEATHERNRF52840 0  // don't do any avr mapping
+#ifndef AUDIO_H
+#define AUDIO_H
 
-#define BLUEMICROV1_0   1
-#define BLUEMICROV1_1   2
-#define BLUEMICROV2_0   3
-#define BLUEMICROV2_0B  4
-#define BLUEMICROV2_0C  5
-#define BLUENANO1_0     6
-#define BLUENANO2_0     7
-#define BLUEMICROV2_1A  8
-#define BLUEMICRO840V1_0 9  // Needs ARDUINO_NRF52840_PCA10056 on the Arduino IDE
+#include <Arduino.h>
+#include "keyboard_config.h"
+#include "firmware_config.h"
 
+void setupAudio();
 
-
-#define COL2ROW       0
-#define ROW2COL       1
-
-#define READ_ON_ROWS       1
-#define READ_ON_COLS       0
-
-#define TEST 0
-#define LEFT 1
-#define RIGHT 2
-#define MASTER 3
-
-#endif  /*HARDWAREVARIANTS_H*/
+#endif

--- a/firmware/avr_mapping.h
+++ b/firmware/avr_mapping.h
@@ -37,6 +37,8 @@ This makes it simpler to migrate from the Arduino Pro Micro to the BlueMicro.
 // BLUENANO2_0     LiPo     RAW connected to LiPo Charger.
 // BLUEMICRO840V1  LiPo     To Come... Currently being designed.
 
+
+
 #ifdef ARDUINO_NRF52832_FEATHER
     #if HARDWARE_MAPPING == BLUEMICROV1_0
         #define BATTERY_TYPE BATT_CR2032
@@ -302,5 +304,6 @@ This makes it simpler to migrate from the Arduino Pro Micro to the BlueMicro.
         #define B6      43 //1.11 = 32+11
     #endif
 #endif
+
 
 #endif /* AVR_MAPPING_H */

--- a/firmware/avr_mapping.h
+++ b/firmware/avr_mapping.h
@@ -37,8 +37,6 @@ This makes it simpler to migrate from the Arduino Pro Micro to the BlueMicro.
 // BLUENANO2_0     LiPo     RAW connected to LiPo Charger.
 // BLUEMICRO840V1  LiPo     To Come... Currently being designed.
 
-
-
 #ifdef ARDUINO_NRF52832_FEATHER
     #if HARDWARE_MAPPING == BLUEMICROV1_0
         #define BATTERY_TYPE BATT_CR2032
@@ -304,6 +302,5 @@ This makes it simpler to migrate from the Arduino Pro Micro to the BlueMicro.
         #define B6      43 //1.11 = 32+11
     #endif
 #endif
-
 
 #endif /* AVR_MAPPING_H */

--- a/firmware/firmware.h
+++ b/firmware/firmware.h
@@ -32,12 +32,17 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #include "LedPwm.h"
 #include "LedRGB.h"
 #include "gpio.h"
+#include "gpioExtension.h"
+#include "audio.h"
+#include "underglow.h"
 
 
     typedef struct { 
           
         bool    ledbacklight;  
-        bool    ledrgb;    
+        bool    ledrgb;
+        bool    ledunderglow;
+        bool    audio;    
         uint32_t timerkeyscaninterval;
         uint32_t timerbatteryinterval;     
   
@@ -64,12 +69,6 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
     #ifndef USER_MACRO_FUNCTION  
     #define USER_MACRO_FUNCTION 1  
     void process_user_macros(uint16_t macroid);
-    #endif
-
-    #if defined(SHIFT_REGISTER_KEYBOARD)
-    void shiftOutToMakeColumnHigh(int column);
-    void shiftOutToMakeAllColumsLow();
-    void shiftOutToMakeAllColumnsHigh();
     #endif
 
 #endif /* FIRMWARE_H */

--- a/firmware/firmware.h
+++ b/firmware/firmware.h
@@ -66,4 +66,10 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
     void process_user_macros(uint16_t macroid);
     #endif
 
+    #if defined(SHIFT_REGISTER_KEYBOARD)
+    void shiftOutToMakeColumnHigh(int column);
+    void shiftOutToMakeAllColumsLow();
+    void shiftOutToMakeAllColumnsHigh();
+    #endif
+
 #endif /* FIRMWARE_H */

--- a/firmware/firmware_config.h
+++ b/firmware/firmware_config.h
@@ -134,6 +134,14 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define BACKLIGHT_PWM_ON 0          
 #endif
 
+#ifndef UNDERGLOW_LED_ON
+#define UNDERGLOW_LED_ON 0          
+#endif
+
+#ifndef AUDIO_ON
+#define AUDIO_ON 0          
+#endif
+
 #define PWM_TOUCH_INTERVAL 1000           // detection time since last keypress.
 #ifndef VBAT_PIN
    #define VBAT_PIN          (A7)

--- a/firmware/firmware_main.cpp
+++ b/firmware/firmware_main.cpp
@@ -27,7 +27,9 @@ using namespace Adafruit_LittleFS_Namespace;
 /**************************************************************************************************************************/
 // Keyboard Matrix
 byte rows[] MATRIX_ROW_PINS;        // Contains the GPIO Pin Numbers defined in keyboard_config.h
+
 byte columns[] MATRIX_COL_PINS;     // Contains the GPIO Pin Numbers defined in keyboard_config.h  
+
 //uint32_t lastupdatetime =0;
 SoftwareTimer keyscantimer, batterytimer;
 
@@ -58,7 +60,7 @@ void setupConfig() {
 void setup() {
  setupConfig();
  Serial.begin(115200);
- // while ( !Serial ) delay(10);   // for nrf52840 with native usb this makes the nrf52840 stall and wait for a serial connection.  Something not wanted for a keyboard...
+  //while ( !Serial ) delay(10);   // for nrf52840 with native usb this makes the nrf52840 stall and wait for a serial connection.  Something not wanted for a keyboard...
 
   LOG_LV1("BLEMIC","Starting %s" ,DEVICE_NAME);
 
@@ -66,6 +68,10 @@ void setup() {
 
   keyscantimer.begin(keyboardconfig.timerkeyscaninterval, keyscantimer_callback);
   batterytimer.begin(keyboardconfig.timerbatteryinterval, batterytimer_callback);
+
+  //Serial.println("***** ENTERING BLE SETUP ***** ");
+  //delay(500);
+
   setupBluetooth();
 
   if(keyboardconfig.ledbacklight)
@@ -77,17 +83,29 @@ void setup() {
   {
     setupRGB();
   }
+  
   // Set up keyboard matrix and start advertising
   setupKeymap();
+
   setupMatrix();
+
   startAdv(); 
+
   keyscantimer.start();
+
   batterytimer.start();
+
+  //Serial.println("***** SUSPENDING MAIN LOOP ***** ");
+  //delay(500);
+
   suspendLoop(); // this commands suspends the main loop.  We are no longer using the loop but scheduling things using the timers.
   stringbuffer.clear();
 };
+
+
+#if !defined(SHIFT_REGISTER_KEYBOARD)
 /**************************************************************************************************************************/
-//
+// Standard setupMatrix() fnc for normal direct I/O connected boards
 /**************************************************************************************************************************/
 void setupMatrix(void) {
     //inits all the columns as INPUT
@@ -101,7 +119,89 @@ void setupMatrix(void) {
       LOG_LV2("BLEMIC","Setting to INPUT_PULLUP Row: %i" ,row);
       pinMode(row, INPUT_PULLUP);
     }
+
+   //setup other peripherals / pins
+
+      //underlighting leds
+      //setup transistor I/O pins as outputs and turn all OFF
+      pinMode(ULED_ROW1, OUTPUT);
+      pinMode(ULED_ROW2, OUTPUT);
+      pinMode(ULED_ROW3, OUTPUT);
+      pinMode(ULED_ROW4, OUTPUT);
+      pinMode(ULED_ROW5, OUTPUT);
+
+      digitalWrite(ULED_ROW1, LOW);
+      digitalWrite(ULED_ROW2, LOW);
+      digitalWrite(ULED_ROW3, LOW);
+      digitalWrite(ULED_ROW4, LOW);
+      digitalWrite(ULED_ROW5, LOW);
+
 };
+#endif
+
+
+#if defined(SHIFT_REGISTER_KEYBOARD)
+/**************************************************************************************************************************/
+// setupMatrix fuc for keybards using shift registers as I/O expanders to drive columns high during the scanning of keys. 
+/**************************************************************************************************************************/
+void setupMatrix(void) {
+
+    //inits all the ROWS INPUT
+   for (const auto& row : rows) {
+      LOG_LV2("BLEMIC","Setting to INPUT ROW: %i" ,row);
+      pinMode(row, INPUT);
+    }
+
+    //inits the shift register pins as outputs and makes them low
+    pinMode(SER_LATCH, OUTPUT);
+    pinMode(SER_DATA, OUTPUT);
+    pinMode(SER_CLK, OUTPUT);
+
+    digitalWrite(SER_LATCH, HIGH);
+    digitalWrite(SER_DATA, LOW);
+    digitalWrite(SER_CLK, LOW);
+
+    //setup other peripherals / pins
+
+
+      //underlighting leds
+      //setup transistor I/O pins as outputs and turn all OFF
+      pinMode(ULED_ROW1, OUTPUT);
+      pinMode(ULED_ROW2, OUTPUT);
+      pinMode(ULED_ROW3, OUTPUT);
+      pinMode(ULED_ROW4, OUTPUT);
+      pinMode(ULED_ROW5, OUTPUT);
+
+      digitalWrite(ULED_ROW1, LOW);
+      digitalWrite(ULED_ROW2, LOW);
+      digitalWrite(ULED_ROW3, LOW);
+      digitalWrite(ULED_ROW4, LOW);
+      digitalWrite(ULED_ROW5, LOW);
+
+      //setup latch and blank for led driver ic
+      pinMode(ULED_LATCH, OUTPUT);
+      pinMode(ULED_BLANK, OUTPUT);
+      pinMode(ULED_SIN, OUTPUT);
+      pinMode(ULED_CLK, OUTPUT);
+
+      digitalWrite(ULED_LATCH, LOW);
+      digitalWrite(ULED_BLANK, HIGH);
+      digitalWrite(ULED_SIN, LOW);
+      digitalWrite(ULED_CLK, LOW);
+
+      //speaker(s)
+      //setup speaker pins
+      pinMode(SPEAKER_A, OUTPUT);
+      pinMode(SPEAKER_B, OUTPUT);
+
+      digitalWrite(SPEAKER_A, LOW);
+      digitalWrite(SPEAKER_B, LOW);
+
+};
+#endif
+
+
+#if !defined(SHIFT_REGISTER_KEYBOARD)
 /**************************************************************************************************************************/
 // Keyboard Scanning
 /**************************************************************************************************************************/
@@ -110,6 +210,7 @@ void scanMatrix() {
   uint32_t pindata1 = 0;
   keyboardstate.timestamp  = millis();   // lets call it once per scan instead of once per key in the matrix
   
+  //Notes: this sets all COLS to input pulldown
     
   for (int i = 0; i < MATRIX_COLS; ++i) {                               // Setting columns before scanning.
         #if DIODE_DIRECTION == COL2ROW                                         
@@ -119,11 +220,19 @@ void scanMatrix() {
         #endif
   }
 
+
+  //loop that scans through "ROWS"
   for(int j = 0; j < MATRIX_ROWS; ++j) {                             
     //set the current row as OUPUT and LOW
     pinMode(rows[j], OUTPUT);
     #if DIODE_DIRECTION == COL2ROW                                         
     digitalWrite(rows[j], LOW);                                       // 'enables' a specific row to be "low" 
+    
+
+    #elif defined(SHIFT_REGISTER_KEYBOARD)
+    //SET ROWS TO LOW w/ shift register 
+    
+
     #else
     digitalWrite(rows[j], HIGH);                                       // 'enables' a specific row to be "HIGH"
     #endif
@@ -131,8 +240,13 @@ void scanMatrix() {
         nrfx_coredep_delay_us(1);   // need for the GPIO lines to settle down electrically before reading.
 
         #ifdef NRF52840_XXAA        // This is chip dependent and not on the board.  As such, we need this to also support the nrf52840 feather which remaps the numbers of the GPIOs to Pins numbers.
+          
+          
           pindata0 = NRF_P0->IN;                                         // read all pins at once
           pindata1 = NRF_P1->IN;                                         // read all pins at once
+          
+
+          //loop that scans through "COLS"
           for (int i = 0; i < MATRIX_COLS; ++i) {
             int ulPin = g_ADigitalPinMap[columns[i]];                               // This maps the Board Pin to the GPIO.
             if (ulPin<32)
@@ -142,7 +256,11 @@ void scanMatrix() {
             {
               KeyScanner::scanMatrix((pindata1>>(ulPin-32))&1, keyboardstate.timestamp, j, i);    // This function processes the logic values and does the debouncing 
             }
-          } 
+          }
+          
+           
+
+
         #else
           pindata0 = NRF_GPIO->IN;                                                // read all pins at once
           for (int i = 0; i < MATRIX_COLS; ++i) {
@@ -157,6 +275,59 @@ void scanMatrix() {
     pinMode(columns[i], INPUT);                                     
   }
 };
+#endif
+
+
+#if defined(SHIFT_REGISTER_KEYBOARD)
+/**************************************************************************************************************************/
+// Keyboard Scanning for SHIFT REGISTER Keyboards
+/**************************************************************************************************************************/
+void scanMatrix() {
+  uint32_t pindata0 = 0;
+  uint32_t pindata1 = 0;
+  keyboardstate.timestamp  = millis();   // lets call it once per scan instead of once per key in the matrix
+  
+
+  //Notes: this sets all ROWS to input pulldown
+  //ROWS must be inputs because shift register outputs are wired to COLS and can only be set to "OUTPUTs"
+  for (int i = 0; i < MATRIX_ROWS; ++i) {                   // Setting rows before scanning.
+        pinMode(rows[i], INPUT_PULLDOWN);                   // 'enables' the row High Value on the diode; becomes "LOW" when pressed
+  }
+
+
+  //loop that scans through "COLS"
+  for(int j = 0; j < MATRIX_COLS; ++j) {        
+
+    //set the current COL as OUTPUT and HIGH using the shift register
+    shiftOutToMakeColumnHigh(j);
+
+      nrfx_coredep_delay_us(1);   // need for the GPIO lines to settle down electrically before reading.
+
+      pindata0 = NRF_P0->IN;                                         // read all pins at once
+      pindata1 = NRF_P1->IN;                                         // read all pins at once
+      
+      //loop that scans through "ROWS"
+      for (int i = 0; i < MATRIX_ROWS; ++i) {
+        int ulPin = g_ADigitalPinMap[rows[i]];                               // This maps the Board Pin to the GPIO.
+        if (ulPin<32)
+        {
+          KeyScanner::scanMatrix((pindata0>>(ulPin))&1, keyboardstate.timestamp, i, j);       // This function processes the logic values and does the debouncing 
+        } else
+        {
+          KeyScanner::scanMatrix((pindata1>>(ulPin-32))&1, keyboardstate.timestamp, i, j);    // This function processes the logic values and does the debouncing 
+        }
+      }
+      
+      shiftOutToMakeAllColumsLow();
+   }                                                                  // done scanning the matrix
+
+
+  for (int i = 0; i < MATRIX_ROWS; ++i) {                             //Scanning done, disabling all rows
+    pinMode(rows[i], INPUT);                                          
+  }
+};
+#endif
+
 
 /**************************************************************************************************************************/
 /**************************************************************************************************************************/
@@ -549,6 +720,8 @@ void keyscantimer_callback(TimerHandle_t _handle) {
 void batterytimer_callback(TimerHandle_t _handle)
 { 
       batterymonitor.updateBattery();
+      //Serial.println("***** LOOP STILL RUNNING ***** ");
+    
 }
 
 
@@ -562,3 +735,51 @@ extern "C" void vApplicationIdleHook(void) {
     sd_power_mode_set(NRF_POWER_MODE_LOWPWR);
     sd_app_evt_wait();  // puts the nrf52 to sleep when there is nothing to do.  You need this to reduce power consumption. (removing this will increase current to 8mA)
 };
+
+
+
+//********************************************************************************************//
+//* Helper functions for Keyboards using Shift Registers to drive columns high in order to   *//
+//* save I/O on nrf52840                                                                     *//
+//* Shift register code is currently setup to use                                            *//
+//********************************************************************************************//
+#if defined(SHIFT_REGISTER_KEYBOARD)
+ 
+    //makes a specific "pin"
+    void shiftOutToMakeColumnHigh(int column){
+
+        uint16_t shiftValue = pow(2, column);
+        uint8_t shiftValLow = shiftValue & 0xFF;
+        uint8_t shiftValHigh = (shiftValue & 0xFF00) >> 8;
+
+        digitalWrite(SER_LATCH, LOW);
+        shiftOut(SER_DATA, SER_CLK, MSBFIRST, shiftValHigh); //first number to 255
+        shiftOut(SER_DATA, SER_CLK, MSBFIRST, shiftValLow); //second number to 255
+        digitalWrite(SER_LATCH, HIGH);
+    }
+
+
+    void shiftOutToMakeAllColumsLow(){
+
+        uint8_t shiftValLow = 0x00;
+        uint8_t shiftValHigh = 0x00;
+
+        digitalWrite(SER_LATCH, LOW);
+        shiftOut(SER_DATA, SER_CLK, LSBFIRST, shiftValHigh); //first number to 255
+        shiftOut(SER_DATA, SER_CLK, LSBFIRST, shiftValLow); //second number to 255
+        digitalWrite(SER_LATCH, HIGH);
+    }
+
+
+    void shiftOutToMakeAllColumnsHigh(){
+
+        uint8_t shiftValLow = 0xFF;
+        uint8_t shiftValHigh = 0xFF;
+
+        digitalWrite(SER_LATCH, LOW);
+        shiftOut(SER_DATA, SER_CLK, LSBFIRST, shiftValHigh); //first number to 255
+        shiftOut(SER_DATA, SER_CLK, LSBFIRST, shiftValLow); //second number to 255
+        digitalWrite(SER_LATCH, HIGH);
+    }
+
+#endif 

--- a/firmware/gpioExtension.cpp
+++ b/firmware/gpioExtension.cpp
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 <Pierre Constantineau>
+
+3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+/*
+ GPIO extension files / library added by Coyt Barringer
+*/
+
+#include "gpioExtension.h"
+
+//********************************************************************************************//
+//* Helper functions for Keyboards using Shift Registers to drive columns high in order to   *//
+//* save I/O on nrf52840                                                                     *//
+//* Shift register code is currently setup to use                                            *//
+//********************************************************************************************//
+
+void setupShiftRegisters(){
+    //inits the shift register pins as outputs and makes them low
+    pinMode(SER_LATCH, OUTPUT);
+    pinMode(SER_DATA, OUTPUT);
+    pinMode(SER_CLK, OUTPUT);
+
+    digitalWrite(SER_LATCH, HIGH);
+    digitalWrite(SER_DATA, LOW);
+    digitalWrite(SER_CLK, LOW);
+}
+
+//makes a specific "pin" high
+void shiftOutToMakePinHigh(int pin){
+
+    uint16_t shiftValue = pow(2, pin);
+    uint8_t shiftValLow = shiftValue & 0xFF;
+    uint8_t shiftValHigh = (shiftValue & 0xFF00) >> 8;
+
+    digitalWrite(SER_LATCH, LOW);
+    shiftOut(SER_DATA, SER_CLK, MSBFIRST, shiftValHigh); //first number to 255
+    shiftOut(SER_DATA, SER_CLK, MSBFIRST, shiftValLow); //second number to 255
+    digitalWrite(SER_LATCH, HIGH);
+}
+
+//makes a specific "pin" low
+void shiftOutToMakePinLow(int pin){
+
+    uint16_t shiftValue = pow(2, pin);
+    uint8_t shiftValLow = shiftValue & 0xFF;
+    uint8_t shiftValHigh = (shiftValue & 0xFF00) >> 8;
+
+    digitalWrite(SER_LATCH, LOW);
+    shiftOut(SER_DATA, SER_CLK, MSBFIRST, shiftValHigh); //first number to 255
+    shiftOut(SER_DATA, SER_CLK, MSBFIRST, shiftValLow); //second number to 255
+    digitalWrite(SER_LATCH, HIGH);
+}
+
+void shiftOutToMakeAllLow(){
+
+    uint8_t shiftValLow = 0x00;
+    uint8_t shiftValHigh = 0x00;
+
+    digitalWrite(SER_LATCH, LOW);
+    shiftOut(SER_DATA, SER_CLK, LSBFIRST, shiftValHigh); //first number to 255
+    shiftOut(SER_DATA, SER_CLK, LSBFIRST, shiftValLow); //second number to 255
+    digitalWrite(SER_LATCH, HIGH);
+}
+
+void shiftOutToMakeAllHigh(){
+
+    uint8_t shiftValLow = 0xFF;
+    uint8_t shiftValHigh = 0xFF;
+
+    digitalWrite(SER_LATCH, LOW);
+    shiftOut(SER_DATA, SER_CLK, LSBFIRST, shiftValHigh); //first number to 255
+    shiftOut(SER_DATA, SER_CLK, LSBFIRST, shiftValLow); //second number to 255
+    digitalWrite(SER_LATCH, HIGH);
+}
+

--- a/firmware/gpioExtension.h
+++ b/firmware/gpioExtension.h
@@ -18,43 +18,21 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 
 */
 
-#ifndef HARDWAREVARIANTS_H
-#define HARDWAREVARIANTS_H
-
 /*
-The following can be selected from the Tools->Boards Arduino Menu when compiling
-NRF52832_FEATHER
-NRF52840_FEATHER
-NRF52840_ITSYBITSY
-NRF52840_CIRCUITPLAY
-NRF52840_METRO
-NRF52840_PCA10056
+ GPIO extension library added by Coyt Barringer 
 */
 
-#define FEATHERNRF52832 0  // don't do any avr mapping
-#define FEATHERNRF52840 0  // don't do any avr mapping
+#ifndef GPIOEXTENTION_H
+#define GPIOEXTENTION_H
 
-#define BLUEMICROV1_0   1
-#define BLUEMICROV1_1   2
-#define BLUEMICROV2_0   3
-#define BLUEMICROV2_0B  4
-#define BLUEMICROV2_0C  5
-#define BLUENANO1_0     6
-#define BLUENANO2_0     7
-#define BLUEMICROV2_1A  8
-#define BLUEMICRO840V1_0 9  // Needs ARDUINO_NRF52840_PCA10056 on the Arduino IDE
+#include <Arduino.h>
+#include "keyboard_config.h"
+#include "firmware_config.h"
 
+void setupShiftRegisters();
+void shiftOutToMakeAllHigh();
+void shiftOutToMakeAllLow();
+void shiftOutToMakePinHigh(int pin);
+void shiftOutToMakePinLow(int pin); 
 
-
-#define COL2ROW       0
-#define ROW2COL       1
-
-#define READ_ON_ROWS       1
-#define READ_ON_COLS       0
-
-#define TEST 0
-#define LEFT 1
-#define RIGHT 2
-#define MASTER 3
-
-#endif  /*HARDWAREVARIANTS_H*/
+#endif

--- a/firmware/keyboards/lost60/keymaps/keymap.cpp
+++ b/firmware/keyboards/lost60/keymaps/keymap.cpp
@@ -1,0 +1,117 @@
+/*
+Copyright 2018 <Pierre Constantineau>
+
+3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+
+/*
+Working keyboard config for LOST60 V1.0 hardware (no shift registers)
+and for LOST60 V2.0 hardware (shift registers for scanning columns)
+NOTE: uses modified "Variant.cpp" for adafruit_feather_nrf52840 to fix pin mappings
+*/
+
+
+#include "keymap.h"
+
+
+#if KEYBOARD_SIDE == MASTER
+
+
+//lost60 ansi layout (fairly standard 60% keyboard mapping)
+std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix =
+{{
+    {KC_ESC,    KC_1,    KC_2,    KC_3,   KC_4,    KC_5,     KC_6,    KC_7,      KC_8,    KC_9,     KC_0,     KC_MINUS,   KC_EQUAL,       KC_BSPACE,},
+    {KC_TAB,    KC_Q,    KC_W,    KC_E,   KC_R,    KC_T,     KC_Y,    KC_U,      KC_I,    KC_O,     KC_P,     KC_LBRC,    KC_RBRACKET,    KC_BSLASH},
+    {LAYER_1,   KC_A,    KC_S,    KC_D,   KC_F,    KC_G,     KC_H,    KC_J,      KC_K,    KC_L,     KC_SCLN,  KC_QUOT,    KC_NO,          KC_ENTER},
+    {KC_LSFT,   KC_NO,   KC_Z,    KC_X,   KC_C,    KC_V,     KC_B,    KC_N,      KC_M,    KC_COMMA, KC_DOT,   KC_SLASH,   KC_NO,          KC_RSFT},
+    {KC_LCTL,   KC_LGUI, KC_LALT, KC_NO,  KC_NO,   KC_SPACE, KC_NO,   KC_NO,     KC_NO,   KC_NO,    KC_LEFT,  KC_RIGHT,   KC_DOWN,        KC_UP}
+}};
+
+
+/*
+//lost60 ansi layout - COL and ROW flipped (used for testing)
+std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix =
+{{
+    {KC_ESC,    KC_TAB,     KC_CAPS,    KC_LSFT,    KC_LCTL,    },
+    {KC_1,      KC_Q,       KC_A,       KC_NO,       KC_LGUI,    },
+    {KC_2,      KC_W,       KC_S,       KC_Z,       KC_LALT,    },
+    {KC_3,      KC_E,       KC_D,       KC_X,       KC_NO,       },
+    {KC_4,      KC_R,       KC_F,       KC_C,       KC_NO,       },
+    {KC_5,      KC_T,       KC_G,       KC_V,       KC_SPACE,       },
+    {KC_6,      KC_Y,       KC_H,       KC_B,       KC_NO,       },
+    {KC_7,      KC_U,       KC_J,       KC_N,       KC_NO,   },
+    {KC_8,      KC_I,       KC_K,       KC_M,       KC_NO,       },
+    {KC_9,      KC_O,       KC_L,       KC_COMMA,   KC_NO,       },
+    {KC_0,      KC_P,       KC_SCLN,    KC_DOT,     KC_LEFT,    },
+    {KC_MINUS,  KC_LBRC,    KC_QUOT,    KC_SLASH,   KC_RIGHT,   },
+    {KC_EQL,    KC_RBRC,    KC_NO,       KC_NO,       KC_DOWN,    },
+    {KC_BSPACE, KC_BSLASH,  KC_RSFT,    KC_RSFT,    KC_UP,      }
+}};
+*/
+
+
+void setupKeymap() {
+
+    //add other layers here
+    
+    uint32_t layer1[MATRIX_ROWS][MATRIX_COLS] =
+    KEYMAP( \
+    KC_GRV,     KC_F1,      KC_F2,      KC_F3,      KC_F4,      KC_F5,      KC_F6,      KC_F7,      KC_F8,      KC_F9,      KC_F10,     KC_F11,     KC_F12,     KC_DEL,     \
+    KC_TRNS,    KC_TRNS,    KC_UP,      KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_PSCR,    KC_SLCK,    KC_PAUS,    KC_TRNS,    \
+    KC_TRNS,    KC_LEFT,    KC_DOWN,    KC_RGHT,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_INS,     KC_HOME,    KC_PGUP,    KC_TRNS,    KC_TRNS,    \
+    KC_TRNS,    KC_TRNS,    KC_VOLU,    KC_VOLD,    KC_MUTE,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_END,     KC_PGDN,    KC_TRNS,    KC_TRNS,    \
+    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    LAYER_2,      KC_TRNS,    KC_TRNS    \
+    ); 
+
+    
+    uint32_t layer2[MATRIX_ROWS][MATRIX_COLS] =
+    KEYMAP( \
+    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    RESET,      \
+    BL_TOGG,    BL_INC,     BL_DEC,     BL_STEP,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    \
+    RGB_TOG,    RGB_MOD,    RGB_HUI,    RGB_SAI,    RGB_VAI,    RGB_SPI,    RGB_M_P,    RGB_M_B,    RGB_M_R,    RGB_M_SW,   KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    \
+    KC_TRNS,    RGB_RMOD,   RGB_HUD,    RGB_SAD,    RGB_VAD,    RGB_SPD,    RGB_M_SN,   RGB_M_K,    RGB_M_X,    RGB_M_G,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    \
+    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS     \
+    );
+    
+
+    /*
+     * add the other layers
+     */
+    for (int row = 0; row < MATRIX_ROWS; ++row)
+    {
+        for (int col = 0; col < MATRIX_COLS; ++col)
+        {
+            matrix[row][col].addActivation(_L1, Method::PRESS, layer1[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, layer2[row][col]);
+        }
+    }
+
+}
+#endif
+
+
+#if KEYBOARD_SIDE == LEFT
+    //LOST60 is not split board
+#endif  // left
+
+
+#if KEYBOARD_SIDE == RIGHT
+    //LOST60 is not split board
+#endif
+
+
+
+

--- a/firmware/keyboards/lost60/keymaps/keymap.cpp
+++ b/firmware/keyboards/lost60/keymaps/keymap.cpp
@@ -37,7 +37,7 @@ std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix =
     {KC_TAB,    KC_Q,    KC_W,    KC_E,   KC_R,    KC_T,     KC_Y,    KC_U,      KC_I,    KC_O,     KC_P,     KC_LBRC,    KC_RBRACKET,    KC_BSLASH},
     {LAYER_1,   KC_A,    KC_S,    KC_D,   KC_F,    KC_G,     KC_H,    KC_J,      KC_K,    KC_L,     KC_SCLN,  KC_QUOT,    KC_NO,          KC_ENTER},
     {KC_LSFT,   KC_NO,   KC_Z,    KC_X,   KC_C,    KC_V,     KC_B,    KC_N,      KC_M,    KC_COMMA, KC_DOT,   KC_SLASH,   KC_NO,          KC_RSFT},
-    {KC_LCTL,   KC_LGUI, KC_LALT, KC_NO,  KC_NO,   KC_SPACE, KC_NO,   KC_NO,     KC_NO,   KC_NO,    KC_LEFT,  KC_RIGHT,   KC_DOWN,        KC_UP}
+    {KC_LCTL,   KC_LGUI, KC_LALT, KC_NO,  KC_NO,   KC_SPACE, KC_NO,   KC_NO,     KC_NO,   KC_ESC,    KC_LEFT,  KC_RIGHT,   KC_DOWN,        KC_UP}
 }};
 
 
@@ -85,7 +85,6 @@ void setupKeymap() {
     KC_TRNS,    RGB_RMOD,   RGB_HUD,    RGB_SAD,    RGB_VAD,    RGB_SPD,    RGB_M_SN,   RGB_M_K,    RGB_M_X,    RGB_M_G,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    \
     KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS     \
     );
-    
 
     /*
      * add the other layers

--- a/firmware/keyboards/lost60/keymaps/keymap.h
+++ b/firmware/keyboards/lost60/keymaps/keymap.h
@@ -18,24 +18,31 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 
 */
 
-#ifndef SLEEP_H
-#define SLEEP_H
-#include <Arduino.h>
-#include <bluefruit.h>
+
+/*
+Working keyboard config for LOST60 V1.0 hardware (no shift registers)
+and for LOST60 V2.0 hardware (shift registers for scanning columns)
+NOTE: uses modified "Variant.cpp" for adafruit_feather_nrf52840 to fix pin mappings
+*/
+
+
+#include <stdint.h>
+#include "hid_keycodes.h"
+#include "hardware_variants.h"
 #include "keyboard_config.h"
-#include "firmware_config.h"
-// Keyboard Matrix
-extern byte rows[]  ;      // Contains the GPIO Pin Numbers defined in keyboard_config.h
-extern byte columns[] ;     // Contains the GPIO Pin Numbers defined in keyboard_config.h  
+#include "advanced_keycodes.h"
+#include "Key.h"
+#include <array>
 
-void setupWakeUp(void);
-void gotoSleep(unsigned long timesincelastkeypress,bool connected);
+#ifndef KEYMAP_H
+#define KEYMAP_H
 
+#define _QWERTY 0
+#define _L1  1
+#define _L2  2
+//#define _L3  3
 
-#if defined(SHIFT_REGISTER_KEYBOARD)
-void shiftOutToMakeColumnHigh2(int column);
-void shiftOutToMakeAllColumsLow2();
-void shiftOutToMakeAllColumnsHigh2();
-#endif
+void setupKeymap();
+extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
 
-#endif
+#endif /* KEYMAP_H */

--- a/firmware/keyboards/lost60/master/keyboard_config.h
+++ b/firmware/keyboards/lost60/master/keyboard_config.h
@@ -33,24 +33,35 @@ NOTE: uses modified "Variant.cpp" for adafruit_feather_nrf52840 to fix pin mappi
 #include "avr_mapping.h"
 
 
-//**********  LOST60 START KEYBOARD HARDWARE VERSION Selection **********
+//********** START CORE Configuration Selection **********
 // COMMENT OUT ALL EXCEPT ONE OF THE FOLLOWING:
 
 #define LOST60_VER_ONE    //this selects code for version 1 of the LOST60 with much less features - used for legacy systems
 //#define LOST60_VER_TWO    //this selects code for version 2 of the LOST60 with significant updates in features.
 
-//********** END KEYBOARD HARDWARE VERSION Selection ************
+//just for testing pin mappings quickly - comment out all except one
+//#define PCA10056_MAPPING
+//#define FEATHER_MAPPING
+
+//********** END CORE Configuration Selection ************
 
 
 //Selector for config based on version of keyboard
 #if defined(LOST60_VER_TWO) 							//for LOST60 V2.0
 
- 	#define SHIFT_REGISTER_KEYBOARD
+ 	//#define SHIFT_REGISTER_KEYBOARD
 
-	//setup pins for shift register / i/o expander if this is what we're using
-  	#define SER_DATA        42      // D42 is P1.13
-	#define SER_CLK         43      // D43 is P1.14
-	#define SER_LATCH       3       // D3  is P1.15
+	#if defined(PCA10056_MAPPING)
+		//setup pins for shift register / i/o expander if this is what we're using
+		#define SER_DATA        45 // is P1.13
+		#define SER_CLK         46 // is P1.14
+		#define SER_LATCH       47 // is P1.15
+	#else 
+		//setup pins for shift register / i/o expander if this is what we're using
+		#define SER_DATA        42      // D42 is P1.13
+		#define SER_CLK         43      // D43 is P1.14
+		#define SER_LATCH       3       // D3  is P1.15
+	#endif 
 
 	#define DEVICE_NAME_R                         	"LOST60 V2 RIGHT"                          	/**< Name of device. Will be included in the advertising data. */
 	#define DEVICE_NAME_L                        	"LOST60 V2 LEFT"                          	/**< Name of device. Will be included in the advertising data. */
@@ -62,59 +73,104 @@ NOTE: uses modified "Variant.cpp" for adafruit_feather_nrf52840 to fix pin mappi
 	// key matrix size 
 	#define MATRIX_ROWS 5
 	#define MATRIX_COLS 14
-	#define MATRIX_ROW_PINS {40, 33, 10, 17, 12} 	//for shift register testing
+
+	//pin definitions for rows
+	#if defined(PCA10056_MAPPING)
+		#define MATRIX_ROW_PINS {43, 9, 27, 28, 8}
+	#else 
+		#define MATRIX_ROW_PINS {40, 33, 10, 17, 12}
+	#endif 
+
 	//these colums do nothing now, but are needed for code to compile - because we haven't tackled full integration
 	//into power optimization code yet. 
-	#define MATRIX_COL_PINS {1} //remove this somehow?
+	#define MATRIX_COL_PINS {1} //remove this somehow? / not used if a shift register keyboard is used
+
+	// if keyboard hardware uses shift registers for I/O expansion within the matrix itself
+	// NOTE: only Shifting Out (I.E. driving shift register pins high) is supported. We can't read from shift registers yet
+	#define SHIFT_REGISTER_KEYBOARD
+
+	/* READ_ON_ROWS or READ_ON_COLS */
+	#define READ_DIRECTION READ_ON_ROWS
 
 	/* COL2ROW or ROW2COL */
 	#define DIODE_DIRECTION ROW2COL //LOST60 V2.0 (shift registers)
 
-	//misc peripherals and pin definitions
-	#define MYLED           6       //D6 is on P0.07
+	//led pin definition
+	#if defined(PCA10056_MAPPING)
+		#define MYLED           7 // is on P0.07
+	#else 
+		#define MYLED           6       //D6 is on P0.07
+	#endif 
 
 	//QSPI Pins
 	//already defined and wired as the default in Variant.cpp
 
-	//Underlighting "neopixels"
-	//#define PIXEL_PIN       14      //D14 is A0 on P0.04   // Digital IO pin connected to the NeoPixels. 
-	//#define PIXEL_COUNT     12      //Number of NeoPixel
-	//#define PIXEL_ENABLE    2       //D2  is P0.10 (NFC2) //enable load switch to turn neopixels on 
-
 	//for switch backlighting leds
-	#define ULED_CLK        25      // D25 is P0.13
-	#define ULED_SIN        26      // D26 is P0.14  
-	#define ULED_LATCH      24      // D24 is on P0.15 
-	#define ULED_BLANK      8       // D8 is on P0.16
+	#define UNDERGLOW_LED_ON 1
+	#if defined(PCA10056_MAPPING)
+		#define ULED_CLK        13 		// is on P0.13
+		#define ULED_SIN        14 		// is on P0.14  
+		#define ULED_LATCH      15 		// is on P0.15 
+		#define ULED_BLANK      16 		// is on P0.16
 
-	#define ULED_ROW1       20      // D20 is A6 on P0.29
-	#define ULED_ROW2       9       // D9 on P0.26
-	#define ULED_ROW3       45      // D45 on P1.12
-	#define ULED_ROW4       16      // D16 is P0.30 (A2)
-	#define ULED_ROW5       21      // D21 is P0.31 (A7, ARef)
+		#define ULED_ROW1       29 		//is on P0.29
+		#define ULED_ROW2       26 		//is on P0.26
+		#define ULED_ROW3       44 		//is on P1.12
+		#define ULED_ROW4       30 		//is on P0.30
+		#define ULED_ROW5       31 		//is on P0.31 
+	#else 
+		#define ULED_CLK        25      // D25 is P0.13
+		#define ULED_SIN        26      // D26 is P0.14  
+		#define ULED_LATCH      24      // D24 is on P0.15 
+		#define ULED_BLANK      8       // D8 is on P0.16
+
+		#define ULED_ROW1       20      // D20 is A6 on P0.29
+		#define ULED_ROW2       9       // D9 on P0.26
+		#define ULED_ROW3       45      // D45 on P1.12
+		#define ULED_ROW4       16      // D16 is P0.30 (A2)
+		#define ULED_ROW5       21      // D21 is P0.31 (A7, ARef)
+	#endif 
 
 	//Speaker Pins
-	#define SPEAKER_A       18      // D18 is P0.02 (A4)
-	#define SPEAKER_B       19      // D19 is P0.03 (A5)
+	#define AUDIO_ON 1
+	#if defined(PCA10056_MAPPING)
+		#define SPEAKER_A       2 		//is P0.02 
+		#define SPEAKER_B       3 		//is P0.03 
+	#else 
+		#define SPEAKER_A       18      // D18 is P0.02 (A4)
+		#define SPEAKER_B       19      // D19 is P0.03 (A5)
+	#endif 
 
 	//Rotary Encoder Pins
-	#define ROTARY_A        15      // D15 is P0.05 (A1)
-	#define ROTARY_B        11      // D11 is P0.06
+	#if defined(PCA10056_MAPPING)
+		#define ROTARY_A        5 		// P0.05
+		#define ROTARY_B        6 		// P0.06
+	#else 
+		#define ROTARY_A        15      // D15 is P0.05 (A1)
+		#define ROTARY_B        11      // D11 is P0.06
+	#endif 
 
 	//I2C Bus Pins
-	#define SCL_PIN         23      // D23 is P0.11 (SCL)
-	#define SDA_PIN         22      // D22 is P0.12 (SDA)
-
+	#if defined(PCA10056_MAPPING)
+		#define SCL_PIN         11 		//is P0.11
+		#define SDA_PIN         12 		//is P0.12
+	#else 
+		#define SCL_PIN         23      // D23 is P0.11 (SCL)
+		#define SDA_PIN         22      // D22 is P0.12 (SDA)
+	#endif 
 
 	//#define BACKLIGHT_PWM_ON 0
-	#define WS2812B_LED_PIN 14 // D14 is P0.04 (A0)
+	#if defined(PCA10056_MAPPING)
+		#define WS2812B_LED_PIN 4 				//is P0.04
+		#define WS2812B_LED_LOAD_SWITCH_PIN 10 	//is P0.10 (NFC2) //enable load switch to turn neopixels on 
+	#else 
+		#define WS2812B_LED_PIN 14 				//D14 is P0.04 (A0)
+		#define WS2812B_LED_LOAD_SWITCH_PIN 2 	//D2  is P0.10 (NFC2) //enable load switch to turn neopixels on 
+	#endif 
 
 	#define WS2812B_LED_LOAD_SWITCH		  	//define this if a hardware load switch is attached to ws2812b for lower power draw
-	#define WS2812B_LED_LOAD_SWITCH_PIN 2 //D2  is P0.10 (NFC2) //enable load switch to turn neopixels on 
-
 	#define WS2812B_LED_COUNT 12
 	#define WS2812B_LED_ON 1 
-
 
 #else 													//for LOST60 V1.0 or other
 
@@ -128,8 +184,15 @@ NOTE: uses modified "Variant.cpp" for adafruit_feather_nrf52840 to fix pin mappi
 	// key matrix size 
 	#define MATRIX_ROWS 5
 	#define MATRIX_COLS 14
-	#define MATRIX_ROW_PINS {1, 32, 10, 17, 28}
-	#define MATRIX_COL_PINS {37, 38, 39, 5, 13, 30, 43, 42, 4, 3, 34, 36, 35, 7}
+
+	//pin definitions for rows and cols
+	#if defined(PCA10056_MAPPING)
+		#define MATRIX_ROW_PINS {24, 21, 27, 28, 20}
+		#define MATRIX_COL_PINS {37, 38, 39, 40, 41, 22, 46, 45, 42, 47, 33, 36, 35, 34}
+	#else 
+		#define MATRIX_ROW_PINS {1, 32, 10, 17, 28}
+		#define MATRIX_COL_PINS {37, 38, 39, 5, 13, 30, 43, 42, 4, 3, 34, 36, 35, 7}
+	#endif 
 
 	/*
 	// HARDWARE DEFINITION
@@ -141,60 +204,67 @@ NOTE: uses modified "Variant.cpp" for adafruit_feather_nrf52840 to fix pin mappi
 	#define MATRIX_COL_PINS {1, 32, 10, 17, 28}//{ F4, F5, F6, F7, B1, B3 }
 	*/
 
+	/* READ_ON_ROWS or READ_ON_COLS */
+	#define READ_DIRECTION READ_ON_ROWS
 
 	/* COL2ROW or ROW2COL */
 	#define DIODE_DIRECTION COL2ROW //LOST60 V1.0 (no shift registers)
 
-	//misc peripherals and pin definitions
-	//#define MYLED           6       //D6 is on P0.07
+	//led pin definition
+	//#if defined(PCA10056_MAPPING)
+	//	#define MYLED           7 // is on P0.07
+	//#else 
+	//	#define MYLED           6       //D6 is on P0.07
+	//#endif 
 
 	//#define VBATPIN A4 //D18 is A4 on P0.02 where voltage divider is connected
 
-	//#define PIXEL_PIN   14  // Digital IO pin connected to the NeoPixels. //D14 is A0 on P0.04
-	//#define PIXEL_COUNT 12  // Number of NeoPixel
-	//#define PIXEL_ENABLE 16 //enable load switch to turn neopixels on //D16 is A2 on P0.30
-
 	//for switch underlighting leds
-	#define ULED_CLK    29 // D29 is on P0.17
-	#define ULED_SIN    26 // D26 is on P0.14 
-	#define ULED_LATCH  24 // D24 is on P0.15 
-	#define ULED_BLANK  8  // D8 is on P0.16
+	#define UNDERGLOW_LED_ON 1
+	#if defined(PCA10056_MAPPING)
+		#define ULED_CLK    17		// is on P0.17
+		#define ULED_SIN    14 		// is on P0.14 
+		#define ULED_LATCH  15 		// is on P0.15 
+		#define ULED_BLANK  16 		// is on P0.16
 
-	#define ULED_ROW1   20 // D20 is A6 on P0.29
-	#define ULED_ROW2   9  // D9 on P0.26
-	#define ULED_ROW3   45 // D45 on P1.12
-	#define ULED_ROW4   31 // D31 is on P0.23
-	#define ULED_ROW5   0  // D0 is on P0.25
+		#define ULED_ROW1   29 		// is on P0.29
+		#define ULED_ROW2   26 		// is on P0.26
+		#define ULED_ROW3   44 		// is on P1.12
+		#define ULED_ROW4   23 		// is on P0.23
+		#define ULED_ROW5   25 		// is on P0.25
+	#else 
+		#define ULED_CLK    29 		// D29 is on P0.17
+		#define ULED_SIN    26 		// D26 is on P0.14 
+		#define ULED_LATCH  24 		// D24 is on P0.15 
+		#define ULED_BLANK  8  		// D8 is on P0.16
+
+		#define ULED_ROW1   20 		// D20 is A6 on P0.29
+		#define ULED_ROW2   9  		// D9 on P0.26
+		#define ULED_ROW3   45 		// D45 on P1.12
+		#define ULED_ROW4   31 		// D31 is on P0.23
+		#define ULED_ROW5   0  		// D0 is on P0.25
+	#endif 
 
 
 	//#define BACKLIGHT_PWM_ON 0
-	#define WS2812B_LED_PIN 14 // D14 is P0.04 (A0)
+	#if defined(PCA10056_MAPPING)
+		#define WS2812B_LED_PIN 			4 	// is P0.04 
+		#define WS2812B_LED_LOAD_SWITCH_PIN 30 	// is P0.30 //enable load switch to turn neopixels on //D16 is A2 on P0.30
+	#else 
+		#define WS2812B_LED_PIN 			14 	// D14 is P0.04 
+		#define WS2812B_LED_LOAD_SWITCH_PIN 16 	// D16 is P0.30 (A2) //enable load switch to turn neopixels on //D16 is A2 on P0.30
+	#endif 
 
 	#define WS2812B_LED_LOAD_SWITCH		  //define this if a hardware load switch is attached to ws2812b for lower power draw
-	#define WS2812B_LED_LOAD_SWITCH_PIN 30 //16 // D16 is P0.30 (A2) //enable load switch to turn neopixels on //D16 is A2 on P0.30
-
 	#define WS2812B_LED_COUNT 12 
 	#define WS2812B_LED_ON 1 
 
-
 #endif 
-
 
 #define KEYBOARD_SIDE MASTER
 // CHANGE THIS FOR THE KEYBOARD TO MATCH WHAT IS BEING FLASHED. OPTIONS: LEFT  RIGHT  MASTER
 
-
 #define UNUSED_PINS {}
-
-
-//#define PERIPHERAL_COUNT 1 // more than 1 doesn't work yet... 
-
-//#define BACKLIGHT_PWM_ON 0
-//#define WS2812B_LED_PIN D3
-
-//#define WS2812B_LED_COUNT 27
-//#define WS2812B_LED_ON 1 
-
 
 //lost60 pin mapping macro - used for more easily setting up QMK style layers in keymap.cpp
 #define KEYMAP( \
@@ -210,7 +280,5 @@ NOTE: uses modified "Variant.cpp" for adafruit_feather_nrf52840 to fix pin mappi
 	{ K30,   K31,   K32,   K33, K34,   K35,   K36,   K37,  K38,   K39,   K310,   K311,	K312,	K313,  },  \
 	{ K30,   K31,   K32,   K33, K34,   K35,   K36,   K37,  K38,   K39,   K310,   K311,	K412,	K413  } \
 }
-
-
 
 #endif /* KEYBOARD_CONFIG_H */

--- a/firmware/keyboards/lost60/master/keyboard_config.h
+++ b/firmware/keyboards/lost60/master/keyboard_config.h
@@ -1,0 +1,216 @@
+/*
+Copyright 2018 <Pierre Constantineau>
+
+3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+
+/*
+Working keyboard config for LOST60 V1.0 hardware (no shift registers)
+and for LOST60 V2.0 hardware (shift registers for scanning columns)
+NOTE: uses modified "Variant.cpp" for adafruit_feather_nrf52840 to fix pin mappings
+*/
+
+
+#ifndef KEYBOARD_CONFIG_H
+#define KEYBOARD_CONFIG_H
+#include "hardware_variants.h"
+#define HARDWARE_MAPPING  BLUEMICRO840V1_0  // note only the BlueMicro840 fits on the corne.
+#include "avr_mapping.h"
+
+
+//**********  LOST60 START KEYBOARD HARDWARE VERSION Selection **********
+// COMMENT OUT ALL EXCEPT ONE OF THE FOLLOWING:
+
+#define LOST60_VER_ONE    //this selects code for version 1 of the LOST60 with much less features - used for legacy systems
+//#define LOST60_VER_TWO    //this selects code for version 2 of the LOST60 with significant updates in features.
+
+//********** END KEYBOARD HARDWARE VERSION Selection ************
+
+
+//Selector for config based on version of keyboard
+#if defined(LOST60_VER_TWO) 							//for LOST60 V2.0
+
+ 	#define SHIFT_REGISTER_KEYBOARD
+
+	//setup pins for shift register / i/o expander if this is what we're using
+  	#define SER_DATA        42      // D42 is P1.13
+	#define SER_CLK         43      // D43 is P1.14
+	#define SER_LATCH       3       // D3  is P1.15
+
+	#define DEVICE_NAME_R                         	"LOST60 V2 RIGHT"                          	/**< Name of device. Will be included in the advertising data. */
+	#define DEVICE_NAME_L                        	"LOST60 V2 LEFT"                          	/**< Name of device. Will be included in the advertising data. */
+	#define DEVICE_NAME_M                         	"LOST60 V2"                          		/**< Name of device. Will be included in the advertising data. */
+	#define DEVICE_MODEL                        	"LOST60 V2"                          		/**< Name of device. Will be included in the advertising data. */
+	#define MANUFACTURER_NAME                   	"Lizard Power Systems"                      /**< Manufacturer. Will be passed to Device Information Service. */
+
+	//HARDWARE DEFINITION
+	// key matrix size 
+	#define MATRIX_ROWS 5
+	#define MATRIX_COLS 14
+	#define MATRIX_ROW_PINS {40, 33, 10, 17, 12} 	//for shift register testing
+	//these colums do nothing now, but are needed for code to compile - because we haven't tackled full integration
+	//into power optimization code yet. 
+	#define MATRIX_COL_PINS {1} //remove this somehow?
+
+	/* COL2ROW or ROW2COL */
+	#define DIODE_DIRECTION ROW2COL //LOST60 V2.0 (shift registers)
+
+	//misc peripherals and pin definitions
+	#define MYLED           6       //D6 is on P0.07
+
+	//QSPI Pins
+	//already defined and wired as the default in Variant.cpp
+
+	//Underlighting "neopixels"
+	//#define PIXEL_PIN       14      //D14 is A0 on P0.04   // Digital IO pin connected to the NeoPixels. 
+	//#define PIXEL_COUNT     12      //Number of NeoPixel
+	//#define PIXEL_ENABLE    2       //D2  is P0.10 (NFC2) //enable load switch to turn neopixels on 
+
+	//for switch backlighting leds
+	#define ULED_CLK        25      // D25 is P0.13
+	#define ULED_SIN        26      // D26 is P0.14  
+	#define ULED_LATCH      24      // D24 is on P0.15 
+	#define ULED_BLANK      8       // D8 is on P0.16
+
+	#define ULED_ROW1       20      // D20 is A6 on P0.29
+	#define ULED_ROW2       9       // D9 on P0.26
+	#define ULED_ROW3       45      // D45 on P1.12
+	#define ULED_ROW4       16      // D16 is P0.30 (A2)
+	#define ULED_ROW5       21      // D21 is P0.31 (A7, ARef)
+
+	//Speaker Pins
+	#define SPEAKER_A       18      // D18 is P0.02 (A4)
+	#define SPEAKER_B       19      // D19 is P0.03 (A5)
+
+	//Rotary Encoder Pins
+	#define ROTARY_A        15      // D15 is P0.05 (A1)
+	#define ROTARY_B        11      // D11 is P0.06
+
+	//I2C Bus Pins
+	#define SCL_PIN         23      // D23 is P0.11 (SCL)
+	#define SDA_PIN         22      // D22 is P0.12 (SDA)
+
+
+	//#define BACKLIGHT_PWM_ON 0
+	#define WS2812B_LED_PIN 14 // D14 is P0.04 (A0)
+
+	#define WS2812B_LED_LOAD_SWITCH		  	//define this if a hardware load switch is attached to ws2812b for lower power draw
+	#define WS2812B_LED_LOAD_SWITCH_PIN 2 //D2  is P0.10 (NFC2) //enable load switch to turn neopixels on 
+
+	#define WS2812B_LED_COUNT 12
+	#define WS2812B_LED_ON 1 
+
+
+#else 													//for LOST60 V1.0 or other
+
+	#define DEVICE_NAME_R                         	"LOST60 V1 RIGHT"                          	/**< Name of device. Will be included in the advertising data. */
+	#define DEVICE_NAME_L                        	"LOST60 V1 LEFT"                          	/**< Name of device. Will be included in the advertising data. */
+	#define DEVICE_NAME_M                         	"LOST60 V1"                          		/**< Name of device. Will be included in the advertising data. */
+	#define DEVICE_MODEL                        	"LOST60 V1"                          		/**< Name of device. Will be included in the advertising data. */
+	#define MANUFACTURER_NAME                   	"Lizard Power Systems"                      /**< Manufacturer. Will be passed to Device Information Service. */
+
+	//HARDWARE DEFINITION
+	// key matrix size 
+	#define MATRIX_ROWS 5
+	#define MATRIX_COLS 14
+	#define MATRIX_ROW_PINS {1, 32, 10, 17, 28}
+	#define MATRIX_COL_PINS {37, 38, 39, 5, 13, 30, 43, 42, 4, 3, 34, 36, 35, 7}
+
+	/*
+	// HARDWARE DEFINITION
+	// KEY MATRIX COLS AND ROWS FLIPPED
+	// key matrix size
+	#define MATRIX_ROWS 14//4
+	#define MATRIX_COLS 5//6
+	#define MATRIX_ROW_PINS {37, 38, 39, 5, 13, 30, 43, 42, 4, 3, 34, 36, 35, 7} //{ D4, C6, D7, E6 }
+	#define MATRIX_COL_PINS {1, 32, 10, 17, 28}//{ F4, F5, F6, F7, B1, B3 }
+	*/
+
+
+	/* COL2ROW or ROW2COL */
+	#define DIODE_DIRECTION COL2ROW //LOST60 V1.0 (no shift registers)
+
+	//misc peripherals and pin definitions
+	//#define MYLED           6       //D6 is on P0.07
+
+	//#define VBATPIN A4 //D18 is A4 on P0.02 where voltage divider is connected
+
+	//#define PIXEL_PIN   14  // Digital IO pin connected to the NeoPixels. //D14 is A0 on P0.04
+	//#define PIXEL_COUNT 12  // Number of NeoPixel
+	//#define PIXEL_ENABLE 16 //enable load switch to turn neopixels on //D16 is A2 on P0.30
+
+	//for switch underlighting leds
+	#define ULED_CLK    29 // D29 is on P0.17
+	#define ULED_SIN    26 // D26 is on P0.14 
+	#define ULED_LATCH  24 // D24 is on P0.15 
+	#define ULED_BLANK  8  // D8 is on P0.16
+
+	#define ULED_ROW1   20 // D20 is A6 on P0.29
+	#define ULED_ROW2   9  // D9 on P0.26
+	#define ULED_ROW3   45 // D45 on P1.12
+	#define ULED_ROW4   31 // D31 is on P0.23
+	#define ULED_ROW5   0  // D0 is on P0.25
+
+
+	//#define BACKLIGHT_PWM_ON 0
+	#define WS2812B_LED_PIN 14 // D14 is P0.04 (A0)
+
+	#define WS2812B_LED_LOAD_SWITCH		  //define this if a hardware load switch is attached to ws2812b for lower power draw
+	#define WS2812B_LED_LOAD_SWITCH_PIN 30 //16 // D16 is P0.30 (A2) //enable load switch to turn neopixels on //D16 is A2 on P0.30
+
+	#define WS2812B_LED_COUNT 12 
+	#define WS2812B_LED_ON 1 
+
+
+#endif 
+
+
+#define KEYBOARD_SIDE MASTER
+// CHANGE THIS FOR THE KEYBOARD TO MATCH WHAT IS BEING FLASHED. OPTIONS: LEFT  RIGHT  MASTER
+
+
+#define UNUSED_PINS {}
+
+
+//#define PERIPHERAL_COUNT 1 // more than 1 doesn't work yet... 
+
+//#define BACKLIGHT_PWM_ON 0
+//#define WS2812B_LED_PIN D3
+
+//#define WS2812B_LED_COUNT 27
+//#define WS2812B_LED_ON 1 
+
+
+//lost60 pin mapping macro - used for more easily setting up QMK style layers in keymap.cpp
+#define KEYMAP( \
+	 K00,   K01,   K02,   K03,  K04,   K05,   K06,   K07,  K08,   K09,   K010,   K011,	K012,	K013,   \
+	 K10,   K11,   K12,   K13,  K14,   K15,   K16,   K17,  K18,   K19,   K110,   K111,	K112,	K113,  	\
+	 K20,   K21,   K22,   K23,  K24,   K25,   K26,   K27,  K28,   K29,   K210,   K211,	K212,	K213,  	\
+	 K30,   K31,   K32,   K33,  K34,   K35,   K36,   K37,  K38,   K39,   K310,   K311,	K312,	K313,	\
+	 K40,   K41,   K42,   K43,  K44,   K45,   K46,   K47,  K48,   K49,   K410,   K411,	K412,	K413	\
+) { \
+	{ K00,   K01,   K02,   K03, K04,   K05,   K06,   K07,  K08,   K09,   K010,   K011,	K012,	K013,  }, \
+	{ K10,   K11,   K12,   K13, K14,   K15,   K16,   K17,  K18,   K19,   K110,   K111,	K112,	K113,  }, \
+	{ K20,   K21,   K22,   K23, K24,   K25,   K26,   K27,  K28,   K29,   K210,   K211,	K212,	K213,  }, \
+	{ K30,   K31,   K32,   K33, K34,   K35,   K36,   K37,  K38,   K39,   K310,   K311,	K312,	K313,  },  \
+	{ K30,   K31,   K32,   K33, K34,   K35,   K36,   K37,  K38,   K39,   K310,   K311,	K412,	K413  } \
+}
+
+
+
+#endif /* KEYBOARD_CONFIG_H */

--- a/firmware/sleep.cpp
+++ b/firmware/sleep.cpp
@@ -19,6 +19,9 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 */
 #include "sleep.h"
 #include "LedRGB.h"
+
+
+#if !defined(SHIFT_REGISTER_KEYBOARD)
 /**************************************************************************************************************************/
 // Prepare sense pins for waking up from complete shutdown
 /**************************************************************************************************************************/
@@ -42,6 +45,27 @@ void setupWakeUp() {
       #endif
   }
 }
+#endif 
+
+
+#if defined(SHIFT_REGISTER_KEYBOARD)
+/**************************************************************************************************************************/
+// Prepare sense pins for waking up from complete shutdown
+/**************************************************************************************************************************/
+void setupWakeUp() {
+  uint32_t pindata = 0;
+
+  //make all column shift registers high - we want all buttons to wait for any one button press
+  shiftOutToMakeAllColumnsHigh2();
+
+  //loops thru all of the rows
+  for (int i = 0; i < MATRIX_ROWS; ++i) {
+        pinMode(rows[i], INPUT_PULLDOWN_SENSE);            // 'enables' the column High Value on the diode; becomes "LOW" when pressed - Sense makes it wake up when sleeping
+  }
+
+}
+#endif
+
 
 /**************************************************************************************************************************/
 void gotoSleep(unsigned long timesincelastkeypress,bool connected)
@@ -68,3 +92,50 @@ void gotoSleep(unsigned long timesincelastkeypress,bool connected)
     sd_power_system_off();
   } 
 }
+ 
+
+//********************************************************************************************//
+//* Helper functions for Keyboards using Shift Registers to drive columns high in order to   *//
+//* save I/O on nrf52840                                                                     *//
+//* Shift register code is currently setup to use                                            *//
+//********************************************************************************************//
+#if defined(SHIFT_REGISTER_KEYBOARD)
+ 
+    //makes a specific "pin"
+    void shiftOutToMakeColumnHigh2(int column){
+
+        uint16_t shiftValue = pow(2, column);
+        uint8_t shiftValLow = shiftValue & 0xFF;
+        uint8_t shiftValHigh = (shiftValue & 0xFF00) >> 8;
+
+        digitalWrite(SER_LATCH, LOW);
+        shiftOut(SER_DATA, SER_CLK, MSBFIRST, shiftValHigh); //first number to 255
+        shiftOut(SER_DATA, SER_CLK, MSBFIRST, shiftValLow); //second number to 255
+        digitalWrite(SER_LATCH, HIGH);
+    }
+
+
+    void shiftOutToMakeAllColumsLow2(){
+
+        uint8_t shiftValLow = 0x00;
+        uint8_t shiftValHigh = 0x00;
+
+        digitalWrite(SER_LATCH, LOW);
+        shiftOut(SER_DATA, SER_CLK, LSBFIRST, shiftValHigh); //first number to 255
+        shiftOut(SER_DATA, SER_CLK, LSBFIRST, shiftValLow); //second number to 255
+        digitalWrite(SER_LATCH, HIGH);
+    }
+
+
+    void shiftOutToMakeAllColumnsHigh2(){
+
+        uint8_t shiftValLow = 0xFF;
+        uint8_t shiftValHigh = 0xFF;
+
+        digitalWrite(SER_LATCH, LOW);
+        shiftOut(SER_DATA, SER_CLK, LSBFIRST, shiftValHigh); //first number to 255
+        shiftOut(SER_DATA, SER_CLK, LSBFIRST, shiftValLow); //second number to 255
+        digitalWrite(SER_LATCH, HIGH);
+    }
+
+#endif 

--- a/firmware/sleep.h
+++ b/firmware/sleep.h
@@ -25,17 +25,11 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #include "keyboard_config.h"
 #include "firmware_config.h"
 // Keyboard Matrix
-extern byte rows[]  ;      // Contains the GPIO Pin Numbers defined in keyboard_config.h
-extern byte columns[] ;     // Contains the GPIO Pin Numbers defined in keyboard_config.h  
+
+extern byte gpioReadIn[]  ;      // Contains the GPIO Pin Numbers defined in keyboard_config.h
+extern byte gpioBias[] ;     // Contains the GPIO Pin Numbers defined in keyboard_config.h  
 
 void setupWakeUp(void);
 void gotoSleep(unsigned long timesincelastkeypress,bool connected);
-
-
-#if defined(SHIFT_REGISTER_KEYBOARD)
-void shiftOutToMakeColumnHigh2(int column);
-void shiftOutToMakeAllColumsLow2();
-void shiftOutToMakeAllColumnsHigh2();
-#endif
 
 #endif

--- a/firmware/underglow.cpp
+++ b/firmware/underglow.cpp
@@ -1,4 +1,4 @@
-/*
+    /*
 Copyright 2019 <Pierre Constantineau>
 
 3-Clause BSD License
@@ -18,43 +18,41 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 
 */
 
-#ifndef HARDWAREVARIANTS_H
-#define HARDWAREVARIANTS_H
-
 /*
-The following can be selected from the Tools->Boards Arduino Menu when compiling
-NRF52832_FEATHER
-NRF52840_FEATHER
-NRF52840_ITSYBITSY
-NRF52840_CIRCUITPLAY
-NRF52840_METRO
-NRF52840_PCA10056
+Underglow files / library added by Coyt Barringer
 */
 
-#define FEATHERNRF52832 0  // don't do any avr mapping
-#define FEATHERNRF52840 0  // don't do any avr mapping
+#include "underglow.h"
+#if UNDERGLOW_LED_ON == 0 
+    //do nothing
+#else
 
-#define BLUEMICROV1_0   1
-#define BLUEMICROV1_1   2
-#define BLUEMICROV2_0   3
-#define BLUEMICROV2_0B  4
-#define BLUEMICROV2_0C  5
-#define BLUENANO1_0     6
-#define BLUENANO2_0     7
-#define BLUEMICROV2_1A  8
-#define BLUEMICRO840V1_0 9  // Needs ARDUINO_NRF52840_PCA10056 on the Arduino IDE
+void setupUnderglow(){
+  
+      //underlighting leds
+      //setup transistor I/O pins as outputs and turn all OFF
+      pinMode(ULED_ROW1, OUTPUT);
+      pinMode(ULED_ROW2, OUTPUT);
+      pinMode(ULED_ROW3, OUTPUT);
+      pinMode(ULED_ROW4, OUTPUT);
+      pinMode(ULED_ROW5, OUTPUT);
 
+      digitalWrite(ULED_ROW1, LOW);
+      digitalWrite(ULED_ROW2, LOW);
+      digitalWrite(ULED_ROW3, LOW);
+      digitalWrite(ULED_ROW4, LOW);
+      digitalWrite(ULED_ROW5, LOW);
 
+      //setup latch and blank for led driver ic
+      pinMode(ULED_LATCH, OUTPUT);
+      pinMode(ULED_BLANK, OUTPUT);
+      pinMode(ULED_SIN, OUTPUT);
+      pinMode(ULED_CLK, OUTPUT);
 
-#define COL2ROW       0
-#define ROW2COL       1
+      digitalWrite(ULED_LATCH, LOW);
+      digitalWrite(ULED_BLANK, HIGH);
+      digitalWrite(ULED_SIN, LOW);
+      digitalWrite(ULED_CLK, LOW);
 
-#define READ_ON_ROWS       1
-#define READ_ON_COLS       0
-
-#define TEST 0
-#define LEFT 1
-#define RIGHT 2
-#define MASTER 3
-
-#endif  /*HARDWAREVARIANTS_H*/
+}    
+#endif

--- a/firmware/underglow.h
+++ b/firmware/underglow.h
@@ -18,43 +18,19 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 
 */
 
-#ifndef HARDWAREVARIANTS_H
-#define HARDWAREVARIANTS_H
-
 /*
-The following can be selected from the Tools->Boards Arduino Menu when compiling
-NRF52832_FEATHER
-NRF52840_FEATHER
-NRF52840_ITSYBITSY
-NRF52840_CIRCUITPLAY
-NRF52840_METRO
-NRF52840_PCA10056
+Underglow files / library added by Coyt Barringer
 */
 
-#define FEATHERNRF52832 0  // don't do any avr mapping
-#define FEATHERNRF52840 0  // don't do any avr mapping
+#ifndef UNDERGLOW_H
+#define UNDERGLOW_H
 
-#define BLUEMICROV1_0   1
-#define BLUEMICROV1_1   2
-#define BLUEMICROV2_0   3
-#define BLUEMICROV2_0B  4
-#define BLUEMICROV2_0C  5
-#define BLUENANO1_0     6
-#define BLUENANO2_0     7
-#define BLUEMICROV2_1A  8
-#define BLUEMICRO840V1_0 9  // Needs ARDUINO_NRF52840_PCA10056 on the Arduino IDE
+#include <Arduino.h>
+#include "keyboard_config.h"
+#include "firmware_config.h"
+
+void setupUnderglow();
+
+#endif
 
 
-
-#define COL2ROW       0
-#define ROW2COL       1
-
-#define READ_ON_ROWS       1
-#define READ_ON_COLS       0
-
-#define TEST 0
-#define LEFT 1
-#define RIGHT 2
-#define MASTER 3
-
-#endif  /*HARDWAREVARIANTS_H*/


### PR DESCRIPTION
Added support for two different versions of my 60% keyboard hardware. 

This required adding some additional scan code to handle the shift registers used in the second version of the hardware. A few areas likely need cleanup - for example, I had to copy my shift register "helper functions" into both the firmware_maincpp and the sleep.cpp files because I wasn't sure the best way to handle this helper code in terms of organization / structure. 

With this pull request, I'm also keeping with the use of the Adafruit feather nrf52840 bootloader and pin-mapping instead of the pca10056 bootloader and pin mapping. Mainly - I'm still ironing out bugs with the pca10056 version and not sure how long that will take. Also the feather bootloader seems to not require a press of the reset button upon code upload which is nice. 

Thanks! 