### PR TITLE
Add nice!nano v1.0 breakout mapping

### DIFF
--- a/firmware/breakout_mapping.h
+++ b/firmware/breakout_mapping.h
@@ -297,7 +297,7 @@ This makes it simpler to migrate from the Arduino Pro Micro to the BlueMicro.
         #define B2      38 //1.06 = 32+6
         #define B6      36 //1.04 = 32+4
         #define NC      33 //1.01 = 32+1 // NC is for not connected....
-        #elif HARDWARE_MAPPING == NRFMICROV0_3
+    #elif HARDWARE_MAPPING == NRFMICROV0_3
         #define BATTERY_TYPE BATT_UNKNOWN
         #define VBAT_PIN  26
         #define D3      6  
@@ -320,6 +320,29 @@ This makes it simpler to migrate from the Arduino Pro Micro to the BlueMicro.
         #define B2      28 
         #define B6      43 //1.11 = 32+11
         #define NC      32 //1.00 = 32+0 // NC is for not connected....
+    #elif HARDWARE_MAPPING == NICE_NANOV1_0
+        #define BATTERY_TYPE BATT_LIPO
+        #define VBAT_PIN  4
+        #define D3      6  
+        #define D2      8   
+        #define D1      17  
+        #define D0      20  
+        #define D4      22
+        #define C6      24
+        #define D7      32 //1.00  = 32+0
+        #define E6      11
+        #define B4      36 //1.04  = 32+4
+        #define B5      38 //1.06  = 32+6
+
+        #define F4      31
+        #define F5      29 
+        #define F6      2
+        #define F7      47 //1.15  = 32+15
+        #define B1      45 //1.13  = 32+13
+        #define B3      43 //1.11 = 32+11
+        #define B2      10
+        #define B6      9
+        #define NC      33 //1.01 = 32+1 // NC is for not connected....
 
   #else // setup defaults for AVR mapping default.
         #define BATTERY_TYPE BATT_LIPO

--- a/firmware/breakout_mapping.h
+++ b/firmware/breakout_mapping.h
@@ -274,7 +274,7 @@ This makes it simpler to migrate from the Arduino Pro Micro to the BlueMicro.
         #define B6      43 //1.11 = 32+11
         #define NC      32 //1.00 = 32+0 // NC is for not connected....
 
-    #elif HARDWARE_MAPPING == NICE_NANOV0_2
+    #elif HARDWARE_MAPPING == NICE_NANOV1_0
         #define BATTERY_TYPE BATT_LIPO
         #define VBAT_PIN  4
         #define D3      6  
@@ -285,8 +285,8 @@ This makes it simpler to migrate from the Arduino Pro Micro to the BlueMicro.
         #define C6      24
         #define D7      32 //1.00  = 32+0
         #define E6      11
-        #define B4      9
-        #define B5      10
+        #define B4      36 //1.04  = 32+4
+        #define B5      38 //1.06  = 32+6
 
         #define F4      31
         #define F5      29 
@@ -294,8 +294,8 @@ This makes it simpler to migrate from the Arduino Pro Micro to the BlueMicro.
         #define F7      47 //1.15  = 32+15
         #define B1      45 //1.13  = 32+13
         #define B3      43 //1.11 = 32+11
-        #define B2      38 //1.06 = 32+6
-        #define B6      36 //1.04 = 32+4
+        #define B2      10
+        #define B6      9
         #define NC      33 //1.01 = 32+1 // NC is for not connected....
     #elif HARDWARE_MAPPING == NRFMICROV0_3
         #define BATTERY_TYPE BATT_UNKNOWN
@@ -320,29 +320,6 @@ This makes it simpler to migrate from the Arduino Pro Micro to the BlueMicro.
         #define B2      28 
         #define B6      43 //1.11 = 32+11
         #define NC      32 //1.00 = 32+0 // NC is for not connected....
-    #elif HARDWARE_MAPPING == NICE_NANOV1_0
-        #define BATTERY_TYPE BATT_LIPO
-        #define VBAT_PIN  4
-        #define D3      6  
-        #define D2      8   
-        #define D1      17  
-        #define D0      20  
-        #define D4      22
-        #define C6      24
-        #define D7      32 //1.00  = 32+0
-        #define E6      11
-        #define B4      36 //1.04  = 32+4
-        #define B5      38 //1.06  = 32+6
-
-        #define F4      31
-        #define F5      29 
-        #define F6      2
-        #define F7      47 //1.15  = 32+15
-        #define B1      45 //1.13  = 32+13
-        #define B3      43 //1.11 = 32+11
-        #define B2      10
-        #define B6      9
-        #define NC      33 //1.01 = 32+1 // NC is for not connected....
 
   #else // setup defaults for AVR mapping default.
         #define BATTERY_TYPE BATT_LIPO

--- a/firmware/hardware_variants.h
+++ b/firmware/hardware_variants.h
@@ -45,6 +45,7 @@ NRF52840_PCA10056
 #define BLUEMICRO840V1_0 9  // Needs ARDUINO_NRF52840_PCA10056 on the Arduino IDE
 #define NICE_NANOV0_2  10
 #define NRFMICROV0_3   11
+#define NICE_NANOV1_0  12
 
 
 #define COL2ROW       0

--- a/firmware/hardware_variants.h
+++ b/firmware/hardware_variants.h
@@ -43,9 +43,9 @@ NRF52840_PCA10056
 #define BLUENANO2_0     7
 #define BLUEMICROV2_1A  8
 #define BLUEMICRO840V1_0 9  // Needs ARDUINO_NRF52840_PCA10056 on the Arduino IDE
-#define NICE_NANOV0_2  10
+#define NICE_NANOV1_0  10
 #define NRFMICROV0_3   11
-#define NICE_NANOV1_0  12
+
 
 
 #define COL2ROW       0

--- a/firmware/keyboards/lily58/left/keyboard_config.h
+++ b/firmware/keyboards/lily58/left/keyboard_config.h
@@ -20,7 +20,7 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #ifndef KEYBOARD_CONFIG_H
 #define KEYBOARD_CONFIG_H
 #include "hardware_variants.h"
-#define HARDWARE_MAPPING  NICE_NANOV0_2  // note only the BlueMicro840 or NiceNano fits on the lily58.
+#define HARDWARE_MAPPING  NICE_NANOV1_0  // note only the BlueMicro840 or NiceNano fits on the lily58.
 #include "breakout_mapping.h"
 
 //#define KEYBOARD_SIDE MASTER

--- a/firmware/keyboards/lily58/master/keyboard_config.h
+++ b/firmware/keyboards/lily58/master/keyboard_config.h
@@ -20,7 +20,7 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #ifndef KEYBOARD_CONFIG_H
 #define KEYBOARD_CONFIG_H
 #include "hardware_variants.h"
-#define HARDWARE_MAPPING  NICE_NANOV0_2  // note only the BlueMicro840 or NiceNano fits on the lily58.
+#define HARDWARE_MAPPING  NICE_NANOV1_0  // note only the BlueMicro840 or NiceNano fits on the lily58.
 #include "breakout_mapping.h"
 
 #define KEYBOARD_SIDE MASTER

--- a/firmware/keyboards/lily58/right/keyboard_config.h
+++ b/firmware/keyboards/lily58/right/keyboard_config.h
@@ -20,7 +20,7 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #ifndef KEYBOARD_CONFIG_H
 #define KEYBOARD_CONFIG_H
 #include "hardware_variants.h"
-#define HARDWARE_MAPPING  NICE_NANOV0_2  // note only the BlueMicro840 or NiceNano fits on the lily58.
+#define HARDWARE_MAPPING  NICE_NANOV1_0  // note only the BlueMicro840 or NiceNano fits on the lily58.
 #include "breakout_mapping.h"
 
 //#define KEYBOARD_SIDE MASTER


### PR DESCRIPTION
Changed Lily58 to use v1 as well (No one else has v0.2 on hand). Maybe remove v0.2? Clears up some clutter.