### PR TITLE
fix build on linux filesystems

### DIFF
--- a/build/build-ubuntu
+++ b/build/build-ubuntu
@@ -55,7 +55,7 @@ arduino_compile() {
    configFile="$keyboardsPath/$keyboard/$target/keyboard_config.h"
 
    cp -f $keymapFile $sourcePath/
-#   cp -f $keymapcppFile $sourcePath/
+   cp -f $keymapcppFile $sourcePath/
    cp -f $configFile $sourcePath/
 
    if $continueOnError; then

--- a/firmware/LedRGB.h
+++ b/firmware/LedRGB.h
@@ -23,7 +23,7 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #include <Arduino.h>
 #include "keyboard_config.h"
 #include "firmware_config.h"
-#include "src\Adafruit_NeoPixel.h"
+#include "src/Adafruit_NeoPixel.h"
 #include "hid_keycodes.h"
 #include "advanced_keycodes.h"
 

--- a/firmware/display.h
+++ b/firmware/display.h
@@ -21,7 +21,7 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #ifndef DISPLAY_H
 #define DISPLAY_H
 #include <Wire.h>
-#include "src\U8g2lib.h"
+#include "src/U8g2lib.h"
 #include "datastructures.h"
 #include <stdio.h>
 

--- a/firmware/firmware_main.cpp
+++ b/firmware/firmware_main.cpp
@@ -22,7 +22,7 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #include "firmware.h"
 #include <Adafruit_LittleFS.h>
 #include <InternalFileSystem.h>
-#include "src\U8g2lib.h"
+#include "src/U8g2lib.h"
 #include <Wire.h>
 using namespace Adafruit_LittleFS_Namespace;
 /**************************************************************************************************************************/


### PR DESCRIPTION
* fix bug in ubuntu build script (commented out file copy for keymap)
* change windows-only path separators (\) to separators that work on all platforms (/)