### PR TITLE
Helix Keyboard support

### DIFF
--- a/firmware/keyboards/helix/config/left/keyboard_config.h
+++ b/firmware/keyboards/helix/config/left/keyboard_config.h
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 <Pierre Constantineau>
+
+3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef KEYBOARD_CONFIG_H
+#define KEYBOARD_CONFIG_H
+
+#include "hardware_config.h"
+
+#define KEYBOARD_SIDE LEFT
+// CHANGE THIS FOR THE KEYBOARD TO MATCH WHAT IS BEING FLASHED. OPTIONS: LEFT  RIGHT  SINGLE
+
+#define DEVICE_NAME_R                        "Helix_R"                          /**< Name of device. Will be included in the advertising data. */
+#define DEVICE_NAME_L                        "Helix_L"                          /**< Name of device. Will be included in the advertising data. */
+#define DEVICE_NAME_M                        "HelixBLE"                         /**< Name of device. Will be included in the advertising data. */
+
+#define DEVICE_MODEL                         "HelixBLE_V1"                      /**< Name of device. Will be included in the advertising data. */
+
+#define MANUFACTURER_NAME                    "MakotoKurauchi"                   /**< Manufacturer. Will be passed to Device Information Service. */
+
+#if KEYBOARD_SIDE == RIGHT
+#define KEYMAP( \
+  R01, R02, R03, R04, R05, R06,     \
+  R11, R12, R13, R14, R15, R16,     \
+  R21, R22, R23, R24, R25, R26,     \
+  R30, R31, R32, R33, R34, R35, R36,\
+  R40, R41, R42, R43, R44, R45, R46 \
+  ) \
+  { \
+    { R06, R05, R04, R03, R02, R01, KC_NO }, \
+    { R16, R15, R14, R13, R12, R11, KC_NO }, \
+    { R26, R25, R24, R23, R22, R21, KC_NO }, \
+    { R36, R35, R34, R33, R32, R31, R30   }, \
+    { R46, R45, R44, R43, R42, R41, R40   }  \
+  }
+#else
+#define KEYMAP( \
+  L00, L01, L02, L03, L04, L05,      \
+  L10, L11, L12, L13, L14, L15,      \
+  L20, L21, L22, L23, L24, L25,      \
+  L30, L31, L32, L33, L34, L35, L36, \
+  L40, L41, L42, L43, L44, L45, L46  \
+  ) \
+  { \
+    { L00, L01, L02, L03, L04, L05, KC_NO }, \
+    { L10, L11, L12, L13, L14, L15, KC_NO }, \
+    { L20, L21, L22, L23, L24, L25, KC_NO }, \
+    { L30, L31, L32, L33, L34, L35, L36   }, \
+    { L40, L41, L42, L43, L44, L45, L46   }  \
+  } 
+
+#endif
+
+#endif /* KEYBOARD_CONFIG_H */
+

--- a/firmware/keyboards/helix/config/right/keyboard_config.h
+++ b/firmware/keyboards/helix/config/right/keyboard_config.h
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 <Pierre Constantineau>
+
+3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef KEYBOARD_CONFIG_H
+#define KEYBOARD_CONFIG_H
+
+#include "hardware_config.h"
+
+#define KEYBOARD_SIDE RIGHT
+// CHANGE THIS FOR THE KEYBOARD TO MATCH WHAT IS BEING FLASHED. OPTIONS: LEFT  RIGHT  SINGLE
+
+#define DEVICE_NAME_R                        "Helix_R"                          /**< Name of device. Will be included in the advertising data. */
+#define DEVICE_NAME_L                        "Helix_L"                          /**< Name of device. Will be included in the advertising data. */
+#define DEVICE_NAME_M                        "HelixBLE"                         /**< Name of device. Will be included in the advertising data. */
+
+#define DEVICE_MODEL                         "HelixBLE_V1"                      /**< Name of device. Will be included in the advertising data. */
+
+#define MANUFACTURER_NAME                    "MakotoKurauchi"                   /**< Manufacturer. Will be passed to Device Information Service. */
+
+#if KEYBOARD_SIDE == RIGHT
+#define KEYMAP( \
+  R01, R02, R03, R04, R05, R06,     \
+  R11, R12, R13, R14, R15, R16,     \
+  R21, R22, R23, R24, R25, R26,     \
+  R30, R31, R32, R33, R34, R35, R36,\
+  R40, R41, R42, R43, R44, R45, R46 \
+  ) \
+  { \
+    { R06, R05, R04, R03, R02, R01, KC_NO }, \
+    { R16, R15, R14, R13, R12, R11, KC_NO }, \
+    { R26, R25, R24, R23, R22, R21, KC_NO }, \
+    { R36, R35, R34, R33, R32, R31, R30   }, \
+    { R46, R45, R44, R43, R42, R41, R40   }  \
+  }
+#else
+#define KEYMAP( \
+  L00, L01, L02, L03, L04, L05,      \
+  L10, L11, L12, L13, L14, L15,      \
+  L20, L21, L22, L23, L24, L25,      \
+  L30, L31, L32, L33, L34, L35, L36, \
+  L40, L41, L42, L43, L44, L45, L46  \
+  ) \
+  { \
+    { L00, L01, L02, L03, L04, L05, KC_NO }, \
+    { L10, L11, L12, L13, L14, L15, KC_NO }, \
+    { L20, L21, L22, L23, L24, L25, KC_NO }, \
+    { L30, L31, L32, L33, L34, L35, L36   }, \
+    { L40, L41, L42, L43, L44, L45, L46   }  \
+  } 
+
+#endif
+
+#endif /* KEYBOARD_CONFIG_H */
+

--- a/firmware/keyboards/helix/config/single/keyboard_config.h
+++ b/firmware/keyboards/helix/config/single/keyboard_config.h
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 <Pierre Constantineau>
+
+3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef KEYBOARD_CONFIG_H
+#define KEYBOARD_CONFIG_H
+
+#include "hardware_config.h"
+
+#define KEYBOARD_SIDE SINGLE
+// CHANGE THIS FOR THE KEYBOARD TO MATCH WHAT IS BEING FLASHED. OPTIONS: LEFT  RIGHT  SINGLE
+
+#define DEVICE_NAME_R                        "Helix_R"                          /**< Name of device. Will be included in the advertising data. */
+#define DEVICE_NAME_L                        "Helix_L"                          /**< Name of device. Will be included in the advertising data. */
+#define DEVICE_NAME_M                        "HelixBLE"                         /**< Name of device. Will be included in the advertising data. */
+
+#define DEVICE_MODEL                         "HelixBLE_V1"                      /**< Name of device. Will be included in the advertising data. */
+
+#define MANUFACTURER_NAME                    "MakotoKurauchi"                   /**< Manufacturer. Will be passed to Device Information Service. */
+
+#if KEYBOARD_SIDE == RIGHT
+#define KEYMAP( \
+  R01, R02, R03, R04, R05, R06,     \
+  R11, R12, R13, R14, R15, R16,     \
+  R21, R22, R23, R24, R25, R26,     \
+  R30, R31, R32, R33, R34, R35, R36,\
+  R40, R41, R42, R43, R44, R45, R46 \
+  ) \
+  { \
+    { R06, R05, R04, R03, R02, R01, KC_NO }, \
+    { R16, R15, R14, R13, R12, R11, KC_NO }, \
+    { R26, R25, R24, R23, R22, R21, KC_NO }, \
+    { R36, R35, R34, R33, R32, R31, R30   }, \
+    { R46, R45, R44, R43, R42, R41, R40   }  \
+  }
+#else
+#define KEYMAP( \
+  L00, L01, L02, L03, L04, L05,      \
+  L10, L11, L12, L13, L14, L15,      \
+  L20, L21, L22, L23, L24, L25,      \
+  L30, L31, L32, L33, L34, L35, L36, \
+  L40, L41, L42, L43, L44, L45, L46  \
+  ) \
+  { \
+    { L00, L01, L02, L03, L04, L05, KC_NO }, \
+    { L10, L11, L12, L13, L14, L15, KC_NO }, \
+    { L20, L21, L22, L23, L24, L25, KC_NO }, \
+    { L30, L31, L32, L33, L34, L35, L36   }, \
+    { L40, L41, L42, L43, L44, L45, L46   }  \
+  } 
+
+#endif
+
+#endif /* KEYBOARD_CONFIG_H */
+

--- a/firmware/keyboards/helix/hardware/pca10056/nice_nano/hardware_config.h
+++ b/firmware/keyboards/helix/hardware/pca10056/nice_nano/hardware_config.h
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 <Pierre Constantineau>
+
+3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef HARDWARE_CONFIG_H
+#define HARDWARE_CONFIG_H
+#include "hardware_variants.h"
+
+
+/* HARDWARE DEFINITION*/
+/* key matrix size */
+#define MATRIX_ROWS 5
+#define MATRIX_COLS 7
+
+#define MATRIX_ROW_PINS { 22, 24, 32, 11, 36 }
+#define MATRIX_COL_PINS { 31, 29,  2, 47, 45, 43, 10 }
+
+#define UNUSED_PINS {}
+
+/* COL2ROW or ROW2COL */
+#define DIODE_DIRECTION COL2ROW
+
+	#define BACKLIGHT_PWM_ON 0
+	#define WS2812B_LED_PIN 6
+	
+	#define WS2812B_LED_COUNT 32
+	#define WS2812B_LED_ON 0 
+       #define BATTERY_TYPE BATT_LIPO
+        #define VBAT_PIN  4
+        #define VCC_PIN 13
+        #define VCC_POLARITY_ON 0
+   /*   #define D3      6  
+        #define D2      8   
+        #define D1      17  
+        #define D0      20  
+        #define D4      22
+        #define C6      24
+        #define D7      32 //1.00  = 32+0
+        #define E6      11
+        #define B4      36 //1.04  = 32+4
+        #define B5      38 //1.06  = 32+6
+
+        #define F4      31
+        #define F5      29 
+        #define F6      2
+        #define F7      47 //1.15  = 32+15
+        #define B1      45 //1.13  = 32+13
+        #define B3      43 //1.11 = 32+11
+        #define B2      10
+        #define B6      9
+        #define NC      33 //1.01 = 32+1 // NC is for not connected....*/
+#endif /* HARDWARE_CONFIG_H */

--- a/firmware/keyboards/helix/keymaps/default/keymap.cpp
+++ b/firmware/keyboards/helix/keymaps/default/keymap.cpp
@@ -1,0 +1,171 @@
+/*
+Copyright 2018 <Pierre Constantineau>
+
+3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include "keymap.h"
+
+
+
+#if KEYBOARD_SIDE == SINGLE
+std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix =
+    {KEYMAP(
+        KC_1,  KC_2,    KC_3,    KC_4,    KC_5,    KC_6,
+        KC_1,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,
+        KC_2,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,
+        KC_3,  KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,   KC_SPC,
+        KC_4,  KC_5,    KC_6,    KC_7,    KC_SPC,  KC_SPC, KC_SPC
+    )};
+
+void setupKeymap() {
+
+   // no layers for master keymap
+   // this is a keymap that's used for testing that each key is responding properly to key presses
+   // flash this keymap to both left and right to test whether each half works properly.
+   // once tested, you can flash the left and right to their respective halves.
+
+}
+#endif
+
+
+#if KEYBOARD_SIDE == LEFT
+
+std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix =
+    {KEYMAP(
+        KC_GRAVE, KC_1,   KC_2,    KC_3,    KC_4, KC_5,
+        KC_TAB,   KC_Q,   KC_W,    KC_E,    KC_R, KC_T,
+        KC_LCTL,  KC_A,   KC_S,    KC_D,    KC_F, KC_G,
+        KC_LSFT,  KC_Z,   KC_X,    KC_C,    KC_V, KC_B,    KC_LBRC,
+        LAYER_3,  KC_ESC, KC_LALT, KC_LCMD, EISU, LAYER_1, KC_SPC
+    )};
+
+ 
+void setupKeymap() {
+
+
+    uint32_t lower[MATRIX_ROWS][MATRIX_COLS] =
+        KEYMAP(
+        KC_TILD, KC_EXLM, KC_AT,   KC_HASH,  KC_DLR,  KC_PERC,         
+        KC_TILD, KC_EXLM, KC_AT,   KC_HASH,  KC_DLR,  KC_PERC,         
+        _______, KC_F1,   KC_F2,   KC_F3,    KC_F4,   KC_F5,           
+        _______, KC_F7,   KC_F8,   KC_F9,    KC_F10,  KC_F11,  KC_LPRN,
+        _______, _______, _______, _______,  _______, LAYER_1, KC_SPC
+);
+
+    uint32_t raise[MATRIX_ROWS][MATRIX_COLS] =
+        KEYMAP( \
+        KC_GRAVE, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,            
+        KC_GRAVE, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,            
+        _______,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,           
+        _______,  KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  _______,
+        _______,  _______, _______, _______, _______, LAYER_3, _______ 
+);
+
+
+    uint32_t adjust[MATRIX_ROWS][MATRIX_COLS] =
+        KEYMAP( \
+        KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,           
+        _______, _______, _______, _______, _______, _______,         
+        _______, _______, _______, _______, _______, _______,         
+        _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______ 
+);
+
+    /*
+     * add the other layers on the regular presses.
+     */
+    for (int row = 0; row < MATRIX_ROWS; ++row)
+    {
+        for (int col = 0; col < MATRIX_COLS; ++col)
+        {
+            matrix[row][col].addActivation(_L1, Method::PRESS, lower[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, raise[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, adjust[row][col]);
+        }
+    }
+
+    // if you want to add Tap/Hold or Tap/Doubletap activations, then you add them below.
+
+}
+
+#endif  // left
+
+
+
+#if KEYBOARD_SIDE == RIGHT
+
+std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix =
+    {KEYMAP(
+                 KC_6,    KC_7, KC_8,     KC_9,    KC_0,      KC_DEL,
+                 KC_Y,    KC_U, KC_I,     KC_O,    KC_P,      KC_BSPACE,
+                 KC_H,    KC_J, KC_K,     KC_L,    KC_SCOLON, KC_QUOTE,
+        KC_RBRC, KC_N,    KC_M, KC_COMMA, KC_DOT,  KC_SLSH,   KC_ENT,
+        KC_SPC,  LAYER_2, EISU, KC_LEFT,  KC_DOWN, KC_UP,     KC_RGHT
+    )};
+
+
+void setupKeymap() {
+
+
+    uint32_t lower[MATRIX_ROWS][MATRIX_COLS] =
+        KEYMAP(
+                 KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, _______,
+                 KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, _______,
+                 KC_F6,   KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE,
+        KC_RBRC, KC_F12,  _______, _______, KC_HOME, KC_END,  _______,
+        _______, LAYER_3, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY 
+);
+
+
+    uint32_t raise[MATRIX_ROWS][MATRIX_COLS] =
+        KEYMAP(
+                 KC_6,    KC_7,     KC_8,     KC_9,    KC_0,    KC_BSPACE,
+                 KC_6,    KC_7,     KC_8,     KC_9,    KC_0,    KC_DEL,
+                 KC_F6,   KC_MINUS, KC_EQUAL, KC_LBRC, KC_RBRC, KC_BSLS,
+        _______, KC_F12,  _______,  _______,  KC_PGDN, KC_PGUP, _______,
+        _______, LAYER_2, _______,  KC_MNXT,  KC_VOLD, KC_VOLU, KC_MPLY
+);
+
+
+    uint32_t adjust[MATRIX_ROWS][MATRIX_COLS] =
+        KEYMAP(
+                 KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,
+                 _______, _______, _______, _______, _______, KC_DEL,
+                 _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______
+);
+
+    /*
+     * add the other layers
+     */
+    for (int row = 0; row < MATRIX_ROWS; ++row)
+    {
+        for (int col = 0; col < MATRIX_COLS; ++col)
+        {
+            matrix[row][col].addActivation(_L1, Method::PRESS, lower[row][col]);
+            matrix[row][col].addActivation(_L2, Method::PRESS, raise[row][col]);
+            matrix[row][col].addActivation(_L3, Method::PRESS, adjust[row][col]);
+        }
+    }
+
+}
+
+
+#endif
+
+
+
+

--- a/firmware/keyboards/helix/keymaps/default/keymap.h
+++ b/firmware/keyboards/helix/keymaps/default/keymap.h
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 <Pierre Constantineau>
+
+3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include <stdint.h>
+#include "hid_keycodes.h"
+#include "keyboard_config.h"
+#include "advanced_keycodes.h"
+#include "Key.h"
+#include <array>
+
+#ifndef KEYMAP_H
+#define KEYMAP_H
+
+#define _QWERTY 0
+#define _L1  1
+#define _L2  2
+#define _L3  3
+#define _L4  4
+
+// Toggles IME input
+#define EISU LALT(KC_GRAVE)
+
+void setupKeymap();
+extern std::array<std::array<Key, MATRIX_COLS>, MATRIX_ROWS> matrix;
+
+#endif /* KEYMAP_H */


### PR DESCRIPTION
Adds a keymap for the [Helix keyboard](https://github.com/MakotoKurauchi/helix) because a few people were interested. 
Copies most of the default 5-row keymap except for the adjust layer which is mostly empty for now.