### PR TITLE
Correct order of params so it matches build output

### DIFF
--- a/build/build-archlinux
+++ b/build/build-archlinux
@@ -157,14 +157,14 @@ else
       selectedTarget="all"
    fi
 
-   selectedHardware="${boardParamSplit[3]}"
-   if [ -z "$selectedHardware" ]; then
-      selectedHardware="all"
-   fi
-
-   selectedFqbn="${boardParamSplit[4]}"
+   selectedFqbn="${boardParamSplit[3]}"
    if [ -z "$selectedFqbn" ]; then
       selectedFqbn="all"
+   fi
+
+   selectedHardware="${boardParamSplit[4]}"
+   if [ -z "$selectedHardware" ]; then
+      selectedHardware="all"
    fi
 
 


### PR DESCRIPTION
Previously if you ran a build of everything, it would print out each target as it built. If you copied one of them and tried to build just that one, it wouldn't find anything.

This is because the param parsing had `fqbn` and `hardware` around the wrong way. This commit fixes that.