### PR TITLE
update adafruit board url

### DIFF
--- a/documentation/docs/getting_started.md
+++ b/documentation/docs/getting_started.md
@@ -30,10 +30,10 @@ Watch the video above to see how to install the Arduino IDE and get the library 
 These are the steps followed in the video (Original Instructions by [Adafruit](https://learn.adafruit.com/bluefruit-nrf52-feather-learning-guide/arduino-bsp-setup)):
 - Download and install the Arduino IDE (At least v1.8). Download it from [here](https://www.arduino.cc/en/Main/Software). Do not install it from the App Store.
 - Start the Arduino IDE
-- Add `https://www.adafruit.com/package_adafruit_index.json` as an **Additional Board Manager URL** (see image below)
+- Add `https://adafruit.github.io/arduino-board-index/package_adafruit_index.json` as an **Additional Board Manager URL** (see image below)
 - To add board Community nRF52 board support, start Arduino and open the Preferences window (**File** > **Preferences**). Now copy and paste the following 2 URLs into the 'Additional Boards Manager URLs' input field:
 
-	https://www.adafruit.com/package_adafruit_index.json
+	https://adafruit.github.io/arduino-board-index/package_adafruit_index.json
 	https://github.com/jpconstantineau/Community_nRF52_Arduino/releases/latest/download/package_jpconstantineau_boards_index.json
 
 ![Board Manager](https://cdn-learn.adafruit.com/assets/assets/000/040/294/large1024/microcontrollers_Screen_Shot_2017-03-19_at_22.16.49.png)

--- a/documentation/docs/installing_tools.mdx
+++ b/documentation/docs/installing_tools.mdx
@@ -19,7 +19,7 @@ import TabItem from '@theme/TabItem';
   
 - Download and install the Arduino IDE (At least v1.8). Download it from [here](https://www.arduino.cc/en/Main/Software). Do not install it from the App Store.
 - Start the Arduino IDE
-- Add `https://www.adafruit.com/package_adafruit_index.json` as an **Additional Board Manager URL** in Preferences.
+- Add `https://adafruit.github.io/arduino-board-index/package_adafruit_index.json` as an **Additional Board Manager URL** in Preferences.
 - Also add `https://github.com/jpconstantineau/Community_nRF52_Arduino/releases/latest/download/package_jpconstantineau_boards_index.json` as an **Additional Board Manager URL** 
 - While you're at it, checking the two "verbose" checkboxes in preferences will help you see compilation details and the commands being used from the IDE.
 
@@ -38,7 +38,7 @@ $ brew cask install arduino
 ```
 
 - Start the Arduino IDE
-- Add `https://www.adafruit.com/package_adafruit_index.json` as an **Additional Board Manager URL** in Preferences.
+- Add `https://adafruit.github.io/arduino-board-index/package_adafruit_index.json` as an **Additional Board Manager URL** in Preferences.
 - Also add `https://github.com/jpconstantineau/Community_nRF52_Arduino/releases/latest/download/package_jpconstantineau_boards_index.json` as an **Additional Board Manager URL** 
 - While you're at it, checking the two "verbose" checkboxes in preferences will help you see compilation details and the commands being used from the IDE.
 

--- a/utils/arduino-cli.yaml
+++ b/utils/arduino-cli.yaml
@@ -1,4 +1,4 @@
 board_manager:
   additional_urls:
-    - https://www.adafruit.com/package_adafruit_index.json
+    - https://adafruit.github.io/arduino-board-index/package_adafruit_index.json
     - https://github.com/jpconstantineau/Community_nRF52_Arduino/releases/latest/download/package_jpconstantineau_boards_index.json


### PR DESCRIPTION
replaces all instances of https://www.adafruit.com/package_adafruit_index.json with https://adafruit.github.io/arduino-board-index/package_adafruit_index.json