### PR TITLE
Updating deprecated use of cask command for macOS

### DIFF
--- a/documentation/docs/installing_tools.mdx
+++ b/documentation/docs/installing_tools.mdx
@@ -34,7 +34,7 @@ After this you are ready to build using `build.ps1` in `build/windows` in PowerS
 
   
 ```
-$ brew cask install arduino
+$ brew install --cask arduino
 ```
 
 - Start the Arduino IDE


### PR DESCRIPTION
[Homebrew v2.6.0](https://brew.sh/2020/12/01/homebrew-2.6.0/) (released Dec 1 2020) deprecated the use of `brew cask` commands in favour of `brew` commands with -- cask when necessary. 

